### PR TITLE
New scheme

### DIFF
--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -159,6 +159,106 @@ std::string ourfunctionsnames[NUMBEROFFNC] = {
   "pospopcnt_u16_avx512_mula_unroll4",  "pospopcnt_u16_avx512_mula_unroll8", "purecircuit"
 };
 
+
+static __m256i avx2_popcount(const __m256i vec) {
+
+    const __m256i lookup = _mm256_setr_epi8(
+        /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
+        /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
+        /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
+        /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4,
+
+        /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
+        /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
+        /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
+        /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4
+    );
+
+    const __m256i low_mask = _mm256_set1_epi8(0x0f);
+
+    const __m256i lo  = _mm256_and_si256(vec, low_mask);
+    const __m256i hi  = _mm256_and_si256(_mm256_srli_epi16(vec, 4), low_mask);
+    const __m256i popcnt1 = _mm256_shuffle_epi8(lookup, lo);
+    const __m256i popcnt2 = _mm256_shuffle_epi8(lookup, hi);
+
+    return _mm256_add_epi8(popcnt1, popcnt2);
+}
+
+
+static __m256i popcount(const __m512i v)
+{
+    const __m256i lo = _mm512_extracti64x4_epi64(v, 0);
+    const __m256i hi = _mm512_extracti64x4_epi64(v, 1);
+    const __m256i s  = _mm256_add_epi8(avx2_popcount(lo), avx2_popcount(hi));
+
+    return _mm256_sad_epu8(s, _mm256_setzero_si256());
+}
+
+
+static uint64_t avx2_sum_epu64(const __m256i v) {
+    
+    return _mm256_extract_epi64(v, 0)
+         + _mm256_extract_epi64(v, 1)
+         + _mm256_extract_epi64(v, 2)
+         + _mm256_extract_epi64(v, 3);
+}
+
+
+static void CSA(__m512i* h, __m512i* l, __m512i a, __m512i b, __m512i c) {
+
+  *l = _mm512_ternarylogic_epi32(c, b, a, 0x96);
+  *h = _mm512_ternarylogic_epi32(c, b, a, 0xe8);
+}
+
+
+static uint64_t popcnt_harley_seal(const __m512i* data, const uint64_t size)
+{
+  __m256i total     = _mm256_setzero_si256();
+  __m512i ones      = _mm512_setzero_si512();
+  __m512i twos      = _mm512_setzero_si512();
+  __m512i fours     = _mm512_setzero_si512();
+  __m512i eights    = _mm512_setzero_si512();
+  __m512i sixteens  = _mm512_setzero_si512();
+  __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;
+
+  const uint64_t limit = size - size % 16;
+  uint64_t i = 0;
+
+  for(; i < limit; i += 16)
+  {
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+0), _mm512_loadu_si512(data+i+1));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+2), _mm512_loadu_si512(data+i+3));
+    CSA(&foursA, &twos, twos, twosA, twosB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+4), _mm512_loadu_si512(data+i+5));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+6), _mm512_loadu_si512(data+i+7));
+    CSA(&foursB, &twos, twos, twosA, twosB);
+    CSA(&eightsA,&fours, fours, foursA, foursB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+8), _mm512_loadu_si512(data+i+9));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+10), _mm512_loadu_si512(data+i+11));
+    CSA(&foursA, &twos, twos, twosA, twosB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+12), _mm512_loadu_si512(data+i+13));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+14), _mm512_loadu_si512(data+i+15));
+    CSA(&foursB, &twos, twos, twosA, twosB);
+    CSA(&eightsB, &fours, fours, foursA, foursB);
+    CSA(&sixteens, &eights, eights, eightsA, eightsB);
+
+    total = _mm256_add_epi64(total, popcount(sixteens));
+  }
+
+  total = _mm256_slli_epi64(total, 4);     // * 16
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(eights), 3)); // += 8 * ...
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(fours),  2)); // += 4 * ...
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(twos),   1)); // += 2 * ...
+  total = _mm256_add_epi64(total, popcount(ones));
+
+  for(; i < size; i++) {
+    total = _mm256_add_epi64(total, popcount(_mm512_loadu_si512(data+i)));
+  }
+
+
+  return avx2_sum_epu64(total);
+}
+
 void print16(uint32_t *flags) {
     for (int k = 0; k < 16; k++)
         printf(" %8u ", flags[k]);
@@ -200,6 +300,57 @@ computeavgs(std::vector< std::vector<unsigned long long> > allresults) {
         answer[z] /= allresults.size();
     }
     return answer;
+}
+
+void measurepopcnt(uint16_t n, uint32_t iterations, bool verbose) {
+    std::vector<int> evts;
+    std::vector<uint16_t> vdata(n);
+    evts.push_back(PERF_COUNT_HW_CPU_CYCLES);
+    evts.push_back(PERF_COUNT_HW_INSTRUCTIONS);
+    evts.push_back(PERF_COUNT_HW_BRANCH_MISSES);
+    evts.push_back(PERF_COUNT_HW_CACHE_REFERENCES);
+    evts.push_back(PERF_COUNT_HW_CACHE_MISSES);
+    LinuxEvents<PERF_TYPE_HARDWARE> unified(evts);
+    std::vector<unsigned long long> results; // tmp buffer
+    std::vector< std::vector<unsigned long long> > allresults;
+    results.resize(evts.size());
+    
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, 0xFFFF);
+
+    n = vdata.size() / (512 / 16) * (512/16);
+    for (uint32_t i = 0; i < iterations; i++) {
+        for (size_t k = 0; k < vdata.size(); k++) {
+            vdata[k] = dis(gen); // random init.
+        }
+        uint64_t expected = popcnt_harley_seal((const __m512i*) vdata.data(), vdata.size() / (512 / 16));       
+        unified.start();
+        uint64_t measured = popcnt_harley_seal((const __m512i*) vdata.data(), vdata.size() / (512 / 16));
+        unified.end(results);
+        assert(measured == expected);
+        allresults.push_back(results);
+    }
+
+    std::vector<unsigned long long> mins = computemins(allresults);
+    std::vector<double> avg = computeavgs(allresults);
+    printf("%-40s\t","avx512popcnt");    
+    if (verbose) {
+        printf("instructions per cycle %4.2f, cycles per 16-bit word:  %4.3f, "
+                "instructions per 16-bit word %4.3f \n",
+                double(mins[1]) / mins[0], double(mins[0]) / n, double(mins[1]) / n);
+        // first we display mins
+        printf("min: %8llu cycles, %8llu instructions, \t%8llu branch mis., %8llu "
+                "cache ref., %8llu cache mis.\n",
+                mins[0], mins[1], mins[2], mins[3], mins[4]);
+        printf("avg: %8.1f cycles, %8.1f instructions, \t%8.1f branch mis., %8.1f "
+                "cache ref., %8.1f cache mis.\n",
+                avg[0], avg[1], avg[2], avg[3], avg[4]);
+    } else {
+        printf("cycles per 16-bit word:  %4.3f \n", double(mins[0]) / n);
+    }
+
+     
 }
 
 
@@ -332,7 +483,7 @@ int main(int argc, char **argv) {
         if (verbose)
             printf("\n");
     }
-
+    measurepopcnt(n, iterations, verbose);
     if (!verbose)
         printf("Try -v to get more details.\n");
 

--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -17,61 +17,40 @@
 
 typedef int (*pospopcnt16)(const uint16_t *, uint32_t, uint32_t *);
 
-#define NUMBEROFFNC 26
-pospopcnt16 ourfunctions[NUMBEROFFNC] = {pospopcnt_u16_scalar_naive_nosimd,
-                                         pospopcnt_u16_scalar_naive,
-                                         pospopcnt_u16_scalar_partition,
-                                         pospopcnt_u16_hist1x4,
-                                         pospopcnt_u16_sse_single,
-                                         pospopcnt_u16_sse_mula,
-                                         pospopcnt_u16_sse_mula_unroll4,
-                                         pospopcnt_u16_sse_mula_unroll8,
-                                         pospopcnt_u16_sse_mula_unroll16,
-                                         pospopcnt_u16_avx2_popcnt,
-                                         pospopcnt_u16_avx2,
-                                         pospopcnt_u16_avx2_naive_counter,
-                                         pospopcnt_u16_avx2_single,
-                                         pospopcnt_u16_avx2_lemire,
-                                         pospopcnt_u16_avx2_lemire2,
-                                         pospopcnt_u16_avx2_mula,
-                                         pospopcnt_u16_avx2_mula_unroll4,
-                                         pospopcnt_u16_avx2_mula_unroll8,
-                                         pospopcnt_u16_avx2_mula_unroll16,
-                                         pospopcnt_u16_avx512,
-                                         pospopcnt_u16_avx512_popcnt32_mask,
-                                         pospopcnt_u16_avx512_popcnt64_mask,
-                                         pospopcnt_u16_avx512_popcnt,
-                                         pospopcnt_u16_avx512_mula,
-                                         pospopcnt_u16_avx512_mula_unroll4,
-                                         pospopcnt_u16_avx512_mula_unroll8};
+#define NUMBEROFFNC 28
+pospopcnt16 ourfunctions[NUMBEROFFNC] = {
+  pospopcnt_u16_scalar_naive_nosimd,  pospopcnt_u16_scalar_naive,
+  pospopcnt_u16_scalar_partition,     pospopcnt_u16_hist1x4,
+  pospopcnt_u16_sse_single,           pospopcnt_u16_sse_mula,
+  pospopcnt_u16_sse_mula_unroll4,     pospopcnt_u16_sse_mula_unroll8,
+  pospopcnt_u16_sse_mula_unroll16,    pospopcnt_u16_avx2_popcnt,
+  pospopcnt_u16_avx2,                 pospopcnt_u16_avx2_naive_counter,
+  pospopcnt_u16_avx2_single,          pospopcnt_u16_avx2_lemire,
+  pospopcnt_u16_avx2_lemire2,         pospopcnt_u16_avx2_mula,
+  pospopcnt_u16_avx2_mula2,           pospopcnt_u16_avx2_mula3,
+  pospopcnt_u16_avx2_mula_unroll4,    pospopcnt_u16_avx2_mula_unroll8,
+  pospopcnt_u16_avx2_mula_unroll16,   pospopcnt_u16_avx512,
+  pospopcnt_u16_avx512_popcnt32_mask, pospopcnt_u16_avx512_popcnt64_mask,
+  pospopcnt_u16_avx512_popcnt,        pospopcnt_u16_avx512_mula,
+  pospopcnt_u16_avx512_mula_unroll4,  pospopcnt_u16_avx512_mula_unroll8
+};
 
 std::string ourfunctionsnames[NUMBEROFFNC] = {
-    "pospopcnt_u16_scalar_naive_nosimd",
-    "pospopcnt_u16_scalar_naive",
-    "pospopcnt_u16_scalar_partition",
-    "pospopcnt_u16_hist1x4",
-    "pospopcnt_u16_sse_single",
-    "pospopcnt_u16_sse_mula",
-    "pospopcnt_u16_sse_mula_unroll4",
-    "pospopcnt_u16_sse_mula_unroll8",
-    "pospopcnt_u16_sse_mula_unroll16",
-    "pospopcnt_u16_avx2_popcnt",
-    "pospopcnt_u16_avx2",
-    "pospopcnt_u16_avx2_naive_counter",
-    "pospopcnt_u16_avx2_single",
-    "pospopcnt_u16_avx2_lemire",
-    "pospopcnt_u16_avx2_lemire2",
-    "pospopcnt_u16_avx2_mula",
-    "pospopcnt_u16_avx2_mula_unroll4",
-    "pospopcnt_u16_avx2_mula_unroll8",
-    "pospopcnt_u16_avx2_mula_unroll16",
-    "pospopcnt_u16_avx512",
-    "pospopcnt_u16_avx512_popcnt32_mask",
-    "pospopcnt_u16_avx512_popcnt64_mask",
-    "pospopcnt_u16_avx512_popcnt",
-    "pospopcnt_u16_avx512_mula",
-    "pospopcnt_u16_avx512_mula_unroll4",
-    "pospopcnt_u16_avx512_mula_unroll8"};
+  "pospopcnt_u16_scalar_naive_nosimd",  "pospopcnt_u16_scalar_naive",
+  "pospopcnt_u16_scalar_partition",     "pospopcnt_u16_hist1x4",
+  "pospopcnt_u16_sse_single",           "pospopcnt_u16_sse_mula",
+  "pospopcnt_u16_sse_mula_unroll4",     "pospopcnt_u16_sse_mula_unroll8",
+  "pospopcnt_u16_sse_mula_unroll16",    "pospopcnt_u16_avx2_popcnt",
+  "pospopcnt_u16_avx2",                 "pospopcnt_u16_avx2_naive_counter",
+  "pospopcnt_u16_avx2_single",          "pospopcnt_u16_avx2_lemire",
+  "pospopcnt_u16_avx2_lemire2",         "pospopcnt_u16_avx2_mula",
+  "pospopcnt_u16_avx2_mula2",           "pospopcnt_u16_avx2_mula3",
+  "pospopcnt_u16_avx2_mula_unroll4",    "pospopcnt_u16_avx2_mula_unroll8",
+  "pospopcnt_u16_avx2_mula_unroll16",   "pospopcnt_u16_avx512",
+  "pospopcnt_u16_avx512_popcnt32_mask", "pospopcnt_u16_avx512_popcnt64_mask",
+  "pospopcnt_u16_avx512_popcnt",        "pospopcnt_u16_avx512_mula",
+  "pospopcnt_u16_avx512_mula_unroll4",  "pospopcnt_u16_avx512_mula_unroll8"
+};
 
 void print16(uint32_t *flags) {
   for (int k = 0; k < 16; k++)
@@ -80,7 +59,7 @@ void print16(uint32_t *flags) {
 }
 
 std::vector<unsigned long long>
-computemins(std::vector<std::vector<unsigned long long>> allresults) {
+computemins(std::vector<std::vector<unsigned long long> > allresults) {
   if (allresults.size() == 0)
     return std::vector<unsigned long long>();
   std::vector<unsigned long long> answer = allresults[0];
@@ -95,7 +74,7 @@ computemins(std::vector<std::vector<unsigned long long>> allresults) {
 }
 
 std::vector<double>
-computeavgs(std::vector<std::vector<unsigned long long>> allresults) {
+computeavgs(std::vector<std::vector<unsigned long long> > allresults) {
   if (allresults.size() == 0)
     return std::vector<double>();
   std::vector<double> answer(allresults[0].size());
@@ -113,7 +92,8 @@ computeavgs(std::vector<std::vector<unsigned long long>> allresults) {
 }
 
 // returns true if the results are correct.
-bool bench(uint16_t n, uint32_t iterations, pospopcnt16 fn, bool verbose) {
+bool bench(uint16_t n, uint32_t iterations, pospopcnt16 fn, bool verbose,
+           bool test) {
   std::vector<int> evts;
   std::vector<uint16_t> vdata(n);
   evts.push_back(PERF_COUNT_HW_CPU_CYCLES);
@@ -123,11 +103,12 @@ bool bench(uint16_t n, uint32_t iterations, pospopcnt16 fn, bool verbose) {
   evts.push_back(PERF_COUNT_HW_CACHE_MISSES);
   LinuxEvents<PERF_TYPE_HARDWARE> unified(evts);
   std::vector<unsigned long long> results; // tmp buffer
-  std::vector<std::vector<unsigned long long>> allresults;
+  std::vector<std::vector<unsigned long long> > allresults;
   results.resize(evts.size());
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<> dis(0, 0xFFFF);
+  bool isok = true;
   for (uint32_t i = 0; i < iterations; i++) {
     for (size_t k = 0; k < vdata.size(); k++) {
       vdata[k] = dis(gen); // random init.
@@ -143,12 +124,16 @@ bool bench(uint16_t n, uint32_t iterations, pospopcnt16 fn, bool verbose) {
     unified.end(results);
     for (size_t k = 0; k < 16; k++) {
       if (correctflags[k] != flags[k]) {
-        printf("bug:\n");
-        printf("expected : ");
-        print16(correctflags);
-        printf("got      : ");
-        print16(flags);
-        return false;
+        if (test) {
+          printf("bug:\n");
+          printf("expected : ");
+          print16(correctflags);
+          printf("got      : ");
+          print16(flags);
+          return false;
+        } else {
+          isok = false;
+        }
       }
     }
     allresults.push_back(results);
@@ -169,7 +154,7 @@ bool bench(uint16_t n, uint32_t iterations, pospopcnt16 fn, bool verbose) {
   } else {
     printf("cycles per 16-bit word:  %4.3f \n", double(mins[0]) / n);
   }
-  return true;
+  return isok;
 }
 
 static void printusage(char *command) {
@@ -207,9 +192,11 @@ int main(int argc, char **argv) {
   for (size_t k = 0; k < NUMBEROFFNC; k++) {
     printf("%-40s\t", ourfunctionsnames[k].c_str());
     fflush(NULL);
-    bool isok = bench(n, iterations, ourfunctions[k], verbose);
+    bool isok = bench(n, iterations, ourfunctions[k], verbose, true);
     if (!isok) {
       printf("Problem detected with %s.\n", ourfunctionsnames[k].c_str());
+      printf("%-40s\t", ourfunctionsnames[k].c_str());
+      bench(n, iterations, ourfunctions[k], verbose, false);
     }
     if (verbose)
       printf("\n");

--- a/fast_flagstats.c
+++ b/fast_flagstats.c
@@ -941,6 +941,33 @@ int pospopcnt_u16_avx2_lemire2(const uint16_t *array, uint32_t len, uint32_t *fl
   return 0;
 }
 
+int pospopcnt_u16_avx2_mula2(const uint16_t* array, uint32_t len, uint32_t* flags) {
+  __m256i counters[16];
+
+  for (size_t i = 0; i < 16; i++) {
+    counters[i] = _mm256_setzero_si256();
+  }
+
+  for (size_t i = 0; i + 16 <= len; i += 16) {
+    __m256i input = _mm256_loadu_si256((__m256i *)(array + i));
+
+    for (int j = 0; j < 16; j++) {
+      __m256i bit = _mm256_and_si256(input, _mm256_set1_epi16(1));
+      counters[j] = _mm256_add_epi16(counters[j], bit);
+      input = _mm256_srli_epi16(input, 1);
+    }
+  }
+
+  uint16_t tmp[16];
+  for (size_t i = 0; i < 16; i++) {
+    _mm256_storeu_si256((__m256i*)tmp, counters[i]);
+    flags[i] = 0;
+    for (int j=0; j < 16; j++)
+      flags[i] += tmp[j];
+  }
+  return 0;
+}
+
 // By Daniel Lemire
 // See: https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/extra/fastflags
 int pospopcnt_u16_avx2_mula(const uint16_t* array, uint32_t len, uint32_t* flags) {
@@ -972,12 +999,197 @@ int pospopcnt_u16_avx2_mula(const uint16_t* array, uint32_t len, uint32_t* flags
             flags[j] += ((array[i] & (1 << j)) >> j);
         }
     }
-
-    //std::cerr << "mula=";
-    //for (int i = 0; i < 16; ++i) std::cerr << " " << flags[i];
-    //std::cerr << std::endl;
-    
+   
     return 0;
+}
+
+int pospopcnt_u16_avx2_mula3(const uint16_t* array, uint32_t len, uint32_t* flags) {
+  __m256i counters[16];
+
+  for (size_t i = 0; i < 16; i++) {
+    counters[i] = _mm256_setzero_si256();
+  }
+
+  const __m256i mask1bit  = _mm256_set1_epi16(0x5555);
+  const __m256i mask2bits = _mm256_set1_epi16(0x3333);
+  const __m256i mask4bits = _mm256_set1_epi16(0x0f0f);
+  const __m256i mask8bits = _mm256_set1_epi16(0x00ff);
+
+  for (size_t i = 0; i + 16*16 <= len; i += 16*16) {
+    __m256i input0 = _mm256_loadu_si256((__m256i *)(array + i + 0x0*16));
+    __m256i input1 = _mm256_loadu_si256((__m256i *)(array + i + 0x1*16));
+    __m256i input2 = _mm256_loadu_si256((__m256i *)(array + i + 0x2*16));
+    __m256i input3 = _mm256_loadu_si256((__m256i *)(array + i + 0x3*16));
+    __m256i input4 = _mm256_loadu_si256((__m256i *)(array + i + 0x4*16));
+    __m256i input5 = _mm256_loadu_si256((__m256i *)(array + i + 0x5*16));
+    __m256i input6 = _mm256_loadu_si256((__m256i *)(array + i + 0x6*16));
+    __m256i input7 = _mm256_loadu_si256((__m256i *)(array + i + 0x7*16));
+    __m256i input8 = _mm256_loadu_si256((__m256i *)(array + i + 0x8*16));
+    __m256i input9 = _mm256_loadu_si256((__m256i *)(array + i + 0x9*16));
+    __m256i inputa = _mm256_loadu_si256((__m256i *)(array + i + 0xa*16));
+    __m256i inputb = _mm256_loadu_si256((__m256i *)(array + i + 0xb*16));
+    __m256i inputc = _mm256_loadu_si256((__m256i *)(array + i + 0xc*16));
+    __m256i inputd = _mm256_loadu_si256((__m256i *)(array + i + 0xd*16));
+    __m256i inpute = _mm256_loadu_si256((__m256i *)(array + i + 0xe*16));
+    __m256i inputf = _mm256_loadu_si256((__m256i *)(array + i + 0xf*16));
+
+    // 1 bit -> 2-bit sums
+    const __m256i sum01_1bit_even = _mm256_add_epi8(input0 & mask1bit, input1 & mask1bit);
+    const __m256i sum23_1bit_even = _mm256_add_epi8(input2 & mask1bit, input3 & mask1bit);
+    const __m256i sum45_1bit_even = _mm256_add_epi8(input4 & mask1bit, input5 & mask1bit);
+    const __m256i sum67_1bit_even = _mm256_add_epi8(input6 & mask1bit, input7 & mask1bit);
+    const __m256i sum89_1bit_even = _mm256_add_epi8(input8 & mask1bit, input9 & mask1bit);
+    const __m256i sumab_1bit_even = _mm256_add_epi8(inputa & mask1bit, inputb & mask1bit);
+    const __m256i sumcd_1bit_even = _mm256_add_epi8(inputc & mask1bit, inputd & mask1bit);
+    const __m256i sumef_1bit_even = _mm256_add_epi8(inpute & mask1bit, inputf & mask1bit);
+
+    const __m256i sum01_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(input0, 1) & mask1bit, _mm256_srli_epi16(input1, 1) & mask1bit);
+    const __m256i sum23_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(input2, 1) & mask1bit, _mm256_srli_epi16(input3, 1) & mask1bit);
+    const __m256i sum45_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(input4, 1) & mask1bit, _mm256_srli_epi16(input5, 1) & mask1bit);
+    const __m256i sum67_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(input6, 1) & mask1bit, _mm256_srli_epi16(input7, 1) & mask1bit);
+    const __m256i sum89_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(input8, 1) & mask1bit, _mm256_srli_epi16(input9, 1) & mask1bit);
+    const __m256i sumab_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(inputa, 1) & mask1bit, _mm256_srli_epi16(inputb, 1) & mask1bit);
+    const __m256i sumcd_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(inputc, 1) & mask1bit, _mm256_srli_epi16(inputd, 1) & mask1bit);
+    const __m256i sumef_1bit_odd = _mm256_add_epi8(_mm256_srli_epi16(inpute, 1) & mask1bit, _mm256_srli_epi16(inputf, 1) & mask1bit);
+
+    // 2-bit -> 4 bit sums
+    input0 = sum01_1bit_even;
+    input1 = sum23_1bit_even;
+    input2 = sum45_1bit_even;
+    input3 = sum67_1bit_even;
+    input4 = sum89_1bit_even;
+    input5 = sumab_1bit_even;
+    input6 = sumcd_1bit_even;
+    input7 = sumef_1bit_even;
+
+    input8 = sum01_1bit_odd;
+    input9 = sum23_1bit_odd;
+    inputa = sum45_1bit_odd;
+    inputb = sum67_1bit_odd;
+    inputc = sum89_1bit_odd;
+    inputd = sumab_1bit_odd;
+    inpute = sumcd_1bit_odd;
+    inputf = sumef_1bit_odd;
+
+    const __m256i sum01_2bits_even = _mm256_add_epi8(input0 & mask2bits, input1 & mask2bits);
+    const __m256i sum23_2bits_even = _mm256_add_epi8(input2 & mask2bits, input3 & mask2bits);
+    const __m256i sum45_2bits_even = _mm256_add_epi8(input4 & mask2bits, input5 & mask2bits);
+    const __m256i sum67_2bits_even = _mm256_add_epi8(input6 & mask2bits, input7 & mask2bits);
+    const __m256i sum89_2bits_even = _mm256_add_epi8(input8 & mask2bits, input9 & mask2bits);
+    const __m256i sumab_2bits_even = _mm256_add_epi8(inputa & mask2bits, inputb & mask2bits);
+    const __m256i sumcd_2bits_even = _mm256_add_epi8(inputc & mask2bits, inputd & mask2bits);
+    const __m256i sumef_2bits_even = _mm256_add_epi8(inpute & mask2bits, inputf & mask2bits);
+
+    const __m256i sum01_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input0, 2) & mask2bits, _mm256_srli_epi16(input1, 2) & mask2bits);
+    const __m256i sum23_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input2, 2) & mask2bits, _mm256_srli_epi16(input3, 2) & mask2bits);
+    const __m256i sum45_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input4, 2) & mask2bits, _mm256_srli_epi16(input5, 2) & mask2bits);
+    const __m256i sum67_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input6, 2) & mask2bits, _mm256_srli_epi16(input7, 2) & mask2bits);
+    const __m256i sum89_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input8, 2) & mask2bits, _mm256_srli_epi16(input9, 2) & mask2bits);
+    const __m256i sumab_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inputa, 2) & mask2bits, _mm256_srli_epi16(inputb, 2) & mask2bits);
+    const __m256i sumcd_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inputc, 2) & mask2bits, _mm256_srli_epi16(inputd, 2) & mask2bits);
+    const __m256i sumef_2bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inpute, 2) & mask2bits, _mm256_srli_epi16(inputf, 2) & mask2bits);
+
+    // 4-bit -> 8-bit sums
+    input0 = sum01_2bits_even;
+    input1 = sum23_2bits_even;
+    input2 = sum45_2bits_even;
+    input3 = sum67_2bits_even;
+    input4 = sum89_2bits_even;
+    input5 = sumab_2bits_even;
+    input6 = sumcd_2bits_even;
+    input7 = sumef_2bits_even;
+
+    input8 = sum01_2bits_odd;
+    input9 = sum23_2bits_odd;
+    inputa = sum45_2bits_odd;
+    inputb = sum67_2bits_odd;
+    inputc = sum89_2bits_odd;
+    inputd = sumab_2bits_odd;
+    inpute = sumcd_2bits_odd;
+    inputf = sumef_2bits_odd;
+
+    const __m256i sum01_4bits_even = _mm256_add_epi8(input0 & mask4bits, input1 & mask4bits);
+    const __m256i sum23_4bits_even = _mm256_add_epi8(input2 & mask4bits, input3 & mask4bits);
+    const __m256i sum45_4bits_even = _mm256_add_epi8(input4 & mask4bits, input5 & mask4bits);
+    const __m256i sum67_4bits_even = _mm256_add_epi8(input6 & mask4bits, input7 & mask4bits);
+    const __m256i sum89_4bits_even = _mm256_add_epi8(input8 & mask4bits, input9 & mask4bits);
+    const __m256i sumab_4bits_even = _mm256_add_epi8(inputa & mask4bits, inputb & mask4bits);
+    const __m256i sumcd_4bits_even = _mm256_add_epi8(inputc & mask4bits, inputd & mask4bits);
+    const __m256i sumef_4bits_even = _mm256_add_epi8(inpute & mask4bits, inputf & mask4bits);
+
+    const __m256i sum01_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input0, 4) & mask4bits, _mm256_srli_epi16(input1, 4) & mask4bits);
+    const __m256i sum23_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input2, 4) & mask4bits, _mm256_srli_epi16(input3, 4) & mask4bits);
+    const __m256i sum45_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input4, 4) & mask4bits, _mm256_srli_epi16(input5, 4) & mask4bits);
+    const __m256i sum67_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input6, 4) & mask4bits, _mm256_srli_epi16(input7, 4) & mask4bits);
+    const __m256i sum89_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(input8, 4) & mask4bits, _mm256_srli_epi16(input9, 4) & mask4bits);
+    const __m256i sumab_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inputa, 4) & mask4bits, _mm256_srli_epi16(inputb, 4) & mask4bits);
+    const __m256i sumcd_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inputc, 4) & mask4bits, _mm256_srli_epi16(inputd, 4) & mask4bits);
+    const __m256i sumef_4bits_odd = _mm256_add_epi8(_mm256_srli_epi16(inpute, 4) & mask4bits, _mm256_srli_epi16(inputf, 4) & mask4bits);
+
+    // 8-bit -> 16-bit sums
+    input0 = sum01_4bits_even;
+    input1 = sum23_4bits_even;
+    input2 = sum45_4bits_even;
+    input3 = sum67_4bits_even;
+    input4 = sum89_4bits_even;
+    input5 = sumab_4bits_even;
+    input6 = sumcd_4bits_even;
+    input7 = sumef_4bits_even;
+
+    input8 = sum01_4bits_odd;
+    input9 = sum23_4bits_odd;
+    inputa = sum45_4bits_odd;
+    inputb = sum67_4bits_odd;
+    inputc = sum89_4bits_odd;
+    inputd = sumab_4bits_odd;
+    inpute = sumcd_4bits_odd;
+    inputf = sumef_4bits_odd;
+
+    const __m256i sum01_8bits_even = _mm256_add_epi16(input0 & mask8bits, input1 & mask8bits);
+    const __m256i sum23_8bits_even = _mm256_add_epi16(input2 & mask8bits, input3 & mask8bits);
+    const __m256i sum45_8bits_even = _mm256_add_epi16(input4 & mask8bits, input5 & mask8bits);
+    const __m256i sum67_8bits_even = _mm256_add_epi16(input6 & mask8bits, input7 & mask8bits);
+    const __m256i sum89_8bits_even = _mm256_add_epi16(input8 & mask8bits, input9 & mask8bits);
+    const __m256i sumab_8bits_even = _mm256_add_epi16(inputa & mask8bits, inputb & mask8bits);
+    const __m256i sumcd_8bits_even = _mm256_add_epi16(inputc & mask8bits, inputd & mask8bits);
+    const __m256i sumef_8bits_even = _mm256_add_epi16(inpute & mask8bits, inputf & mask8bits);
+
+    const __m256i sum01_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(input0, 8) & mask8bits, _mm256_srli_epi16(input1, 8) & mask8bits);
+    const __m256i sum23_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(input2, 8) & mask8bits, _mm256_srli_epi16(input3, 8) & mask8bits);
+    const __m256i sum45_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(input4, 8) & mask8bits, _mm256_srli_epi16(input5, 8) & mask8bits);
+    const __m256i sum67_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(input6, 8) & mask8bits, _mm256_srli_epi16(input7, 8) & mask8bits);
+    const __m256i sum89_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(input8, 8) & mask8bits, _mm256_srli_epi16(input9, 8) & mask8bits);
+    const __m256i sumab_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(inputa, 8) & mask8bits, _mm256_srli_epi16(inputb, 8) & mask8bits);
+    const __m256i sumcd_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(inputc, 8) & mask8bits, _mm256_srli_epi16(inputd, 8) & mask8bits);
+    const __m256i sumef_8bits_odd = _mm256_add_epi16(_mm256_srli_epi16(inpute, 8) & mask8bits, _mm256_srli_epi16(inputf, 8) & mask8bits);
+
+    counters[0x0] = _mm256_add_epi16(counters[0x0], sum01_8bits_even);
+    counters[0x1] = _mm256_add_epi16(counters[0x1], sum23_8bits_even);
+    counters[0x2] = _mm256_add_epi16(counters[0x2], sum45_8bits_even);
+    counters[0x3] = _mm256_add_epi16(counters[0x3], sum67_8bits_even);
+    counters[0x4] = _mm256_add_epi16(counters[0x4], sum89_8bits_even);
+    counters[0x5] = _mm256_add_epi16(counters[0x5], sumab_8bits_even);
+    counters[0x6] = _mm256_add_epi16(counters[0x6], sumcd_8bits_even);
+    counters[0x7] = _mm256_add_epi16(counters[0x7], sumef_8bits_even);
+
+    counters[0x8] = _mm256_add_epi16(counters[0x8], sum01_8bits_odd);
+    counters[0x9] = _mm256_add_epi16(counters[0x9], sum23_8bits_odd);
+    counters[0xa] = _mm256_add_epi16(counters[0xa], sum45_8bits_odd);
+    counters[0xb] = _mm256_add_epi16(counters[0xb], sum67_8bits_odd);
+    counters[0xc] = _mm256_add_epi16(counters[0xc], sum89_8bits_odd);
+    counters[0xd] = _mm256_add_epi16(counters[0xd], sumab_8bits_odd);
+    counters[0xe] = _mm256_add_epi16(counters[0xe], sumcd_8bits_odd);
+    counters[0xf] = _mm256_add_epi16(counters[0xf], sumef_8bits_odd);
+  }
+
+  uint16_t tmp[16];
+  for (size_t i = 0; i < 16; i++) {
+    _mm256_storeu_si256((__m256i*)tmp, counters[i]);
+    flags[i] = 0;
+    for (int j=0; j < 16; j++)
+      flags[i] += tmp[j];
+  }
+  return 0;
 }
 
 int pospopcnt_u16_avx2_mula_unroll4(const uint16_t* array, uint32_t len, uint32_t* flags) {

--- a/fast_flagstats.h
+++ b/fast_flagstats.h
@@ -165,6 +165,8 @@ int pospopcnt_u16_avx2_single(const uint16_t* data, uint32_t n, uint32_t* flags)
 int pospopcnt_u16_avx2_lemire(const uint16_t* data, uint32_t n, uint32_t* flags);
 int pospopcnt_u16_avx2_lemire2(const uint16_t* data, uint32_t n, uint32_t* flags);
 int pospopcnt_u16_avx2_mula(const uint16_t* data, uint32_t n, uint32_t* flags);
+int pospopcnt_u16_avx2_mula2(const uint16_t* data, uint32_t n, uint32_t* flags);
+int pospopcnt_u16_avx2_mula3(const uint16_t* data, uint32_t n, uint32_t* flags);
 int pospopcnt_u16_avx2_mula_unroll4(const uint16_t* data, uint32_t n, uint32_t* flags);
 int pospopcnt_u16_avx2_mula_unroll8(const uint16_t* data, uint32_t n, uint32_t* flags);
 int pospopcnt_u16_avx2_mula_unroll16(const uint16_t* data, uint32_t n, uint32_t* flags);


### PR DESCRIPTION
The new `pospopcnt_u16_avx2_mula3` is the fastest so far. The only caveat is that it is not quite correct. Also it is not ported to AVX-512. With some luck it should be able to achieve 0.3 cycles per 16-bit word using AVX-512.

```
pospopcnt_u16_avx2_mula3                	cycles per 16-bit word:  0.381
(...)
pospopcnt_u16_avx512_mula               	cycles per 16-bit word:  0.686
pospopcnt_u16_avx512_mula_unroll4       	cycles per 16-bit word:  0.582
pospopcnt_u16_avx512_mula_unroll8       	cycles per 16-bit word:  0.585
```

cc @WojciechMula