### PR TITLE
Minor optimization (improving avx512_csa)

### DIFF
--- a/benchmark/linux/popcnt.h
+++ b/benchmark/linux/popcnt.h
@@ -1,0 +1,103 @@
+#ifndef POPCNT
+#define POPCNT
+#include <x86intrin.h>
+
+static __m256i avx2_popcount(const __m256i vec) {
+
+      const __m256i lookup = _mm256_setr_epi8(
+         /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
+         /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
+         /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
+         /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4,
+
+          /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
+         /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
+         /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
+         /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4
+     );
+
+      const __m256i low_mask = _mm256_set1_epi8(0x0f);
+
+      const __m256i lo  = _mm256_and_si256(vec, low_mask);
+     const __m256i hi  = _mm256_and_si256(_mm256_srli_epi16(vec, 4), low_mask);
+     const __m256i popcnt1 = _mm256_shuffle_epi8(lookup, lo);
+     const __m256i popcnt2 = _mm256_shuffle_epi8(lookup, hi);
+
+      return _mm256_add_epi8(popcnt1, popcnt2);
+}
+
+static __m256i popcount(const __m512i v)
+{
+    const __m256i lo = _mm512_extracti64x4_epi64(v, 0);
+    const __m256i hi = _mm512_extracti64x4_epi64(v, 1);
+    const __m256i s  = _mm256_add_epi8(avx2_popcount(lo), avx2_popcount(hi));
+
+    return _mm256_sad_epu8(s, _mm256_setzero_si256());
+}
+
+
+static uint64_t avx2_sum_epu64(const __m256i v) {
+    
+    return _mm256_extract_epi64(v, 0)
+         + _mm256_extract_epi64(v, 1)
+         + _mm256_extract_epi64(v, 2)
+         + _mm256_extract_epi64(v, 3);
+}
+
+
+static void CSA(__m512i* h, __m512i* l, __m512i a, __m512i b, __m512i c) {
+
+  *l = _mm512_ternarylogic_epi32(c, b, a, 0x96);
+  *h = _mm512_ternarylogic_epi32(c, b, a, 0xe8);
+}
+
+
+static uint64_t popcnt_harley_seal(const __m512i* data, const uint64_t size)
+{
+  __m256i total     = _mm256_setzero_si256();
+  __m512i ones      = _mm512_setzero_si512();
+  __m512i twos      = _mm512_setzero_si512();
+  __m512i fours     = _mm512_setzero_si512();
+  __m512i eights    = _mm512_setzero_si512();
+  __m512i sixteens  = _mm512_setzero_si512();
+  __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;
+
+  const uint64_t limit = size - size % 16;
+  uint64_t i = 0;
+
+  for(; i < limit; i += 16)
+  {
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+0), _mm512_loadu_si512(data+i+1));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+2), _mm512_loadu_si512(data+i+3));
+    CSA(&foursA, &twos, twos, twosA, twosB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+4), _mm512_loadu_si512(data+i+5));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+6), _mm512_loadu_si512(data+i+7));
+    CSA(&foursB, &twos, twos, twosA, twosB);
+    CSA(&eightsA,&fours, fours, foursA, foursB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+8), _mm512_loadu_si512(data+i+9));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+10), _mm512_loadu_si512(data+i+11));
+    CSA(&foursA, &twos, twos, twosA, twosB);
+    CSA(&twosA, &ones, ones, _mm512_loadu_si512(data+i+12), _mm512_loadu_si512(data+i+13));
+    CSA(&twosB, &ones, ones, _mm512_loadu_si512(data+i+14), _mm512_loadu_si512(data+i+15));
+    CSA(&foursB, &twos, twos, twosA, twosB);
+    CSA(&eightsB, &fours, fours, foursA, foursB);
+    CSA(&sixteens, &eights, eights, eightsA, eightsB);
+
+    total = _mm256_add_epi64(total, popcount(sixteens));
+  }
+
+  total = _mm256_slli_epi64(total, 4);     // * 16
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(eights), 3)); // += 8 * ...
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(fours),  2)); // += 4 * ...
+  total = _mm256_add_epi64(total, _mm256_slli_epi64(popcount(twos),   1)); // += 2 * ...
+  total = _mm256_add_epi64(total, popcount(ones));
+
+  for(; i < size; i++) {
+    total = _mm256_add_epi64(total, popcount(_mm512_loadu_si512(data+i)));
+  }
+
+
+  return avx2_sum_epu64(total);
+}
+
+#endif

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -142,9 +142,8 @@ PPOPCNT_INLINE void POSPOPCNT_CSA_AVX512(__m512i* __restrict__ h,
                                          __m512i* __restrict__ l, 
                                          __m512i b, __m512i c) 
 {
-     const __m512i u = _mm512_xor_si512(*l, b);
-     *h = _mm512_or_si512(*l & b, u & c);
-     *l = _mm512_xor_si512(u, c);
+     *h = _mm512_ternarylogic_epi32(c, b, *l, 0xe8);
+     *l = _mm512_ternarylogic_epi32(c, b, *l, 0x96);
 }
 #endif // endif simd_version >= 6
 


### PR DESCRIPTION
 and putting back the standard popcnt which is important as it is a known lower bound on the cycle count.

We are now running at
```
pospopcnt_u16_avx512_csa                	cycles per 16-bit word:  0.166 
avx512popcnt                            	cycles per 16-bit word:  0.086 
```

You can do the standard popcnt using about 0.344 cycles per 64-bit word (or 4 x 16 bits). It takes about 0.66 cycles to do the 16-bit pospopcnt of a 64-bit word.

If you try to do the same thing without SIMD instructions, it takes 70 cycles for the same task. 

In other words, SIMD instructions make the code run 100 faster.

@WojciechMula 