### PR TITLE
Measuring the counter overhead.

### DIFF
--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -225,14 +225,14 @@ bool benchmarkMany(uint32_t n, uint32_t m, uint32_t iterations, pospopcnt_u16_me
             }
         }
         std::vector<std::vector<uint32_t>> correctflags(m,std::vector<uint32_t>(16));
-        for (size_t k = 0; k < vdata.size(); k++) {
-          pospopcnt_u16_scalar_naive(vdata[k].data(), vdata.size(), correctflags[k].data()); // this is our gold standard
+        for (size_t k = 0; k < m; k++) {
+          pospopcnt_u16_scalar_naive(vdata[k].data(), vdata[k].size(), correctflags[k].data()); // this is our gold standard
         }
         std::vector<std::vector<uint32_t>> flags(m,std::vector<uint32_t>(16));
         
         unified.start();
-        for (size_t k = 0; k < vdata.size(); k++) {
-          fn(vdata[k].data(), vdata.size(), flags[k].data());
+        for (size_t k = 0; k < m ; k++) {
+          fn(vdata[k].data(), vdata[k].size(), flags[k].data());
         }
         unified.end(results);
 

--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -254,6 +254,43 @@ void measurepopcnt(uint32_t n, uint32_t iterations, bool verbose) {
     }
 }
 #endif
+void measureoverhead(uint32_t n, uint32_t iterations, bool verbose) {
+    std::vector<int> evts;
+    evts.push_back(PERF_COUNT_HW_CPU_CYCLES);
+    evts.push_back(PERF_COUNT_HW_INSTRUCTIONS);
+    evts.push_back(PERF_COUNT_HW_BRANCH_MISSES);
+    evts.push_back(PERF_COUNT_HW_CACHE_REFERENCES);
+    evts.push_back(PERF_COUNT_HW_CACHE_MISSES);
+    evts.push_back(PERF_COUNT_HW_REF_CPU_CYCLES);
+    LinuxEvents<PERF_TYPE_HARDWARE> unified(evts);
+    std::vector<unsigned long long> results; // tmp buffer
+    std::vector< std::vector<unsigned long long> > allresults;
+    results.resize(evts.size());
+    
+    for (uint32_t i = 0; i < iterations; i++) {
+        unified.start();
+        unified.end(results);
+        allresults.push_back(results);
+    }
+
+    std::vector<unsigned long long> mins = compute_mins(allresults);
+    std::vector<double> avg = compute_averages(allresults);
+    printf("%-40s\t","nothing");    
+    if (verbose) {
+        printf("instructions per cycle %4.2f, cycles per 16-bit word:  %4.3f, "
+               "instructions per 16-bit word %4.3f \n",
+                double(mins[1]) / mins[0], double(mins[0]) / n, double(mins[1]) / n);
+        // first we display mins
+        printf("min: %8llu cycles, %8llu instructions, \t%8llu branch mis., %8llu "
+               "cache ref., %8llu cache mis.\n",
+                mins[0], mins[1], mins[2], mins[3], mins[4]);
+        printf("avg: %8.1f cycles, %8.1f instructions, \t%8.1f branch mis., %8.1f "
+               "cache ref., %8.1f cache mis.\n",
+                avg[0], avg[1], avg[2], avg[3], avg[4]);
+    } else {
+        printf("cycles per 16-bit word:  %4.3f; ref cycles per 16-bit word: %4.3f \n", double(mins[0]) / n, double(mins[5]) / n);
+    }
+}
 
 static void print_usage(char *command) {
     printf(" Try %s -n 100000 -i 15 -v \n", command);
@@ -320,6 +357,7 @@ int main(int argc, char **argv) {
 #if POSPOPCNT_SIMD_VERSION >= 5
     measurepopcnt(n, iterations, verbose);
 #endif
+    measureoverhead(n, iterations, verbose);
    
     for (size_t k = 0; k < PPOPCNT_NUMBER_METHODS; k++) {
         printf("%-40s\t", pospopcnt_u16_method_names[k]);


### PR DESCRIPTION
Let us measure the overhead of our counters. It is about 13 instructions and 60 cycles.

```
nothing                                 	instructions per cycle 0.26, cycles per 16-bit word:  0.001, instructions per 16-bit word 0.000
min:       50 cycles,       13 instructions, 	       0 branch mis.,        0 cache ref.,        0 cache mis.
avg:     60.6 cycles,     13.0 instructions, 	     0.0 branch mis.,      0.2 cache ref.,      0.0 cache mis.
```

By default, we test with `n = 100000`. Clearly, 50 cycles / n is going to be zero.

Testing with tiny values like `n = 1000`, the counter overhead would become more significant. But for  `n >= 100000`, it is clearly fine.