### PR TITLE
Eliminate warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@
 ###################################################################
 
 OPTFLAGS  := -O3 -march=native
-CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS)
-CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS)
+WARNFLAGS := -Wall -Wextra -pedantic
+CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
+CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPP_SOURCE = benchmark.cpp benchmark/linux/instrumented_benchmark.cpp
 C_SOURCE   = pospopcnt.c example.c
 OBJECTS    = $(CPP_SOURCE:.cpp=.o) $(C_SOURCE:.c=.o)
@@ -28,10 +29,10 @@ all: bench
 
 # Generic rules
 %.o: %.c
-	$(CC) $(CFLAGS)-c -o $@ $<
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 %.o: %.cpp
-	$(CXX) $(CPPFLAGS)-c -o $@ $<
+	$(CXX) $(CPPFLAGS) -c -o $@ $<
 
 benchmark/linux/instrumented_benchmark.o : benchmark/linux/instrumented_benchmark.cpp
 	$(CXX) $(CPPFLAGS) -I. -Ibenchmark/linux -c -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 ###################################################################
 
 OPTFLAGS  := -O3 -march=native
-WARNFLAGS := -Wall -Wextra -pedantic
+WARNFLAGS := # -Wall -Wextra -pedantic
 CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPP_SOURCE = benchmark.cpp benchmark/linux/instrumented_benchmark.cpp

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This benchmark shows the speedup of the 3 `pospopcnt` algorithms used on x86 CPU
 | pospopcnt_u16_sse_blend_popcnt_unroll8    | **2.09** | 3.16 | 2.35 | 1.88 | 1.67 | 1.56 | 1.5  | 1.44  |
 | pospopcnt_u16_avx512_blend_popcnt_unroll8 | 1.78 | **3.61** | **3.61** | 3.59 | 3.68 | 3.65 | 3.67 | 3.7   |
 | pospopcnt_u16_avx512_adder_forest        | 0.77 | 0.9  | 3.24 | **3.96** | **4.96** | 5.87 | 6.52 | 7.24  |
-| pospopcnt_u16_avx512_harvey_seal          | 0.52 | 0.74 | 1.83 | 2.64 | 4.06 | **6.43** | **9.41** | **16.28** |
+| pospopcnt_u16_avx512_harley_seal          | 0.52 | 0.74 | 1.83 | 2.64 | 4.06 | **6.43** | **9.41** | **16.28** |
 
 Compared to a naive unvectorized solution (`pospopcnt_u16_scalar_naive_nosimd`):
 
@@ -28,7 +28,7 @@ Compared to a naive unvectorized solution (`pospopcnt_u16_scalar_naive_nosimd`):
 | pospopcnt_u16_sse_blend_popcnt_unroll8    | **8.28** | 9.84  | 10.55 | 11    | 11.58 | 11.93 | 12.13 | 12.28  |
 | pospopcnt_u16_avx512_blend_popcnt_unroll8 | 7.07 | **11.25** | **16.21** | 21    | 25.49 | 27.91 | 29.73 | 31.55  |
 | pospopcnt_u16_avx512_adder_forest        | 3.05 | 2.82  | 14.53 | **23.13** | **34.37** | 44.91 | 52.78 | 61.68  |
-| pospopcnt_u16_avx512_harvey_seal          | 2.07 | 2.3   | 8.21  | 15.41 | 28.17 | **49.14** | **76.11** | **138.71** |
+| pospopcnt_u16_avx512_harley_seal          | 2.07 | 2.3   | 8.21  | 15.41 | 28.17 | **49.14** | **76.11** | **138.71** |
 
 The host architecture used is a 10 nm Cannon Lake [Core i3-8121U](https://ark.intel.com/content/www/us/en/ark/products/136863/intel-core-i3-8121u-processor-4m-cache-up-to-3-20-ghz.html) with gcc (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5).
 

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -1652,7 +1652,7 @@ int pospopcnt_u16_avx2_blend_popcnt_unroll4(const uint16_t* array, uint32_t len,
             A(0,1) A(2, 3)
 
 #define P0(p) input##p = _mm256_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3)
         }
     }
@@ -1709,7 +1709,7 @@ int pospopcnt_u16_avx2_blend_popcnt_unroll8(const uint16_t* array, uint32_t len,
             A(0,1) A(2, 3) A(4, 5) A(6, 7)
 
 #define P0(p) input##p = _mm256_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3) P(4, 5) P(6, 7)
         }
     }
@@ -1780,7 +1780,7 @@ int pospopcnt_u16_avx2_blend_popcnt_unroll16(const uint16_t* array, uint32_t len
             A(8,9) A(10,11) A(12,13) A(14,15)
 
 #define P0(p) input##p = _mm256_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
+#define P(p, k) P0(p) P0(k)
             P(0,1) P( 2, 3) P( 4, 5) P( 6, 7)
             P(8,9) P(10,11) P(12,13) P(14,15)
         }
@@ -1900,8 +1900,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll4(const uint16_t* array, uint32_t len, 
             A(0,1) A(2, 3)
 
 #define P0(p) input##p = _mm_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
-
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3)
         }
     }
@@ -1972,8 +1971,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll8(const uint16_t* array, uint32_t len, 
             A(0,1) A(2, 3) A(4,5) A(6, 7)
 
 #define P0(p) input##p = _mm_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
-
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3) P(4,5) P(6, 7)
         }
     }
@@ -2045,8 +2043,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* array, uint32_t len,
             A(8,9) A(10, 11) A(12,13) A(14, 15)
 
 #define P0(p) input##p = _mm_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
-
+#define P(p, k) P0(p) P0(k)
             P(0,1) P( 2,  3) P( 4, 5) P( 6,  7)
             P(8,9) P(10, 11) P(12,13) P(14, 15)
         }
@@ -2312,8 +2309,7 @@ int pospopcnt_u16_avx512bw_blend_popcnt_unroll4(const uint16_t* data, uint32_t l
             A(0,1) A(2, 3)
 
 #define P0(p) input##p = _mm512_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
-
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3)
         }
     }
@@ -2371,8 +2367,7 @@ int pospopcnt_u16_avx512bw_blend_popcnt_unroll8(const uint16_t* data, uint32_t l
             A(0,1) A(2, 3) A(4,5) A(6, 7)
 
 #define P0(p) input##p = _mm512_add_epi8(input##p, input##p);
-#define P(p, k) input##p = P0(p) P0(k)
-
+#define P(p, k) P0(p) P0(k)
             P(0,1) P(2, 3) P(4,5) P(6, 7)
         }
     }

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -31,13 +31,13 @@ int pospopcnt_u16(const uint16_t* data, uint32_t len, uint32_t* flags) {
     else if (len < 256)  return(pospopcnt_u16_sse_blend_popcnt_unroll8(data, len, flags)); // small
     else if (len < 512)  return(pospopcnt_u16_avx512bw_blend_popcnt_unroll8(data, len, flags)); // medium
     else if (len < 4096) return(pospopcnt_u16_avx512bw_adder_forest(data, len, flags)); // medium3
-    else return(pospopcnt_u16_avx512_harvey_seal(data, len, flags)); // fix
+    else return(pospopcnt_u16_avx512_harley_seal(data, len, flags)); // fix
 #elif POSPOPCNT_SIMD_VERSION >= 5
     if (len < 128) return(pospopcnt_u16_sse_sad(data, len, flags)); // small
     else if (len < 1024) return(pospopcnt_u16_avx2_blend_popcnt_unroll8(data, len, flags)); // medium
-    else return(pospopcnt_u16_avx2_harvey_seal(data, len, flags)); // large
+    else return(pospopcnt_u16_avx2_harley_seal(data, len, flags)); // large
 #elif POSPOPCNT_SIMD_VERSION >= 3
-    return(pospopcnt_u16_sse_harvey_seal(data, len, flags));
+    return(pospopcnt_u16_sse_harley_seal(data, len, flags));
 #else
     #ifndef _MSC_VER
         return(pospopcnt_u16_scalar_umul128_unroll2(data, len, flags)); // fallback scalar
@@ -62,7 +62,7 @@ int pospopcnt_u16_method(PPOPCNT_U16_METHODS method, const uint16_t* data, uint3
     case(PPOPCNT_SSE_BLEND_POPCNT_UR8): return pospopcnt_u16_sse_blend_popcnt_unroll8(data, len, flags);
     case(PPOPCNT_SSE_BLEND_POPCNT_UR16): return pospopcnt_u16_sse_blend_popcnt_unroll16(data, len, flags);
     case(PPOPCNT_SSE_SAD): return pospopcnt_u16_sse_sad(data, len, flags);
-    case(PPOPCNT_SSE_HARVEY_SEAL): return pospopcnt_u16_sse_harvey_seal(data, len, flags);
+    case(PPOPCNT_SSE_HARLEY_SEAL): return pospopcnt_u16_sse_harley_seal(data, len, flags);
     case(PPOPCNT_AVX2_POPCNT): return pospopcnt_u16_avx2_popcnt(data, len, flags);
     case(PPOPCNT_AVX2): return pospopcnt_u16_avx2(data, len, flags);
     case(PPOPCNT_AVX2_POPCNT_NAIVE): return pospopcnt_u16_avx2_naive_counter(data, len, flags);
@@ -74,19 +74,19 @@ int pospopcnt_u16_method(PPOPCNT_U16_METHODS method, const uint16_t* data, uint3
     case(PPOPCNT_AVX2_BLEND_POPCNT_UR8): return pospopcnt_u16_avx2_blend_popcnt_unroll8(data, len, flags);
     case(PPOPCNT_AVX2_BLEND_POPCNT_UR16): return pospopcnt_u16_avx2_blend_popcnt_unroll16(data, len, flags);
     case(PPOPCNT_AVX2_ADDER_FOREST): return pospopcnt_u16_avx2_adder_forest(data, len, flags);
-    case(PPOPCNT_AVX2_HARVEY_SEAL): return pospopcnt_u16_avx2_harvey_seal(data, len, flags);
+    case(PPOPCNT_AVX2_HARLEY_SEAL): return pospopcnt_u16_avx2_harley_seal(data, len, flags);
     case(PPOPCNT_AVX512): return pospopcnt_u16_avx512(data, len, flags);
     case(PPOPCNT_AVX512BW_MASK32): return pospopcnt_u16_avx512bw_popcnt32_mask(data, len, flags);
     case(PPOPCNT_AVX512BW_MASK64): return pospopcnt_u16_avx512bw_popcnt64_mask(data, len, flags);
-    case(PPOSCNT_AVX512_MASKED_OPS): return pospopcnt_u16_avx512_masked_ops(data, len, flags);
+    case(PPOPCNT_AVX512_MASKED_OPS): return pospopcnt_u16_avx512_masked_ops(data, len, flags);
     case(PPOPCNT_AVX512_POPCNT): return pospopcnt_u16_avx512_popcnt(data, len, flags);
     case(PPOPCNT_AVX512BW_BLEND_POPCNT): return pospopcnt_u16_avx512bw_blend_popcnt(data, len, flags);
     case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR4): return pospopcnt_u16_avx512bw_blend_popcnt_unroll4(data, len, flags);
     case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR8): return pospopcnt_u16_avx512bw_blend_popcnt_unroll8(data, len, flags);
     case(PPOPCNT_AVX512BW_ADDER_FOREST): return pospopcnt_u16_avx512bw_adder_forest(data, len, flags);
     case(PPOPCNT_AVX512_MULA2): return pospopcnt_u16_avx512_mula2(data, len, flags);
-    case(PPOPCNT_AVX512BW_HARVEY_SEAL): return pospopcnt_u16_avx512bw_harvey_seal(data, len, flags);
-    case(PPOPCNT_AVX512VBMI_HARVEY_SEAL): return pospopcnt_u16_avx512vbmi_harvey_seal(data, len, flags);
+    case(PPOPCNT_AVX512BW_HARLEY_SEAL): return pospopcnt_u16_avx512bw_harley_seal(data, len, flags);
+    case(PPOPCNT_AVX512VBMI_HARLEY_SEAL): return pospopcnt_u16_avx512vbmi_harley_seal(data, len, flags);
     case PPOPCNT_NUMBER_METHODS: break; /* -Wswitch */
     }
     assert(0);
@@ -108,7 +108,7 @@ pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method) {
     case(PPOPCNT_SSE_BLEND_POPCNT_UR8): return pospopcnt_u16_sse_blend_popcnt_unroll8;
     case(PPOPCNT_SSE_BLEND_POPCNT_UR16): return pospopcnt_u16_sse_blend_popcnt_unroll16;
     case(PPOPCNT_SSE_SAD): return pospopcnt_u16_sse_sad;
-    case(PPOPCNT_SSE_HARVEY_SEAL): return pospopcnt_u16_sse_harvey_seal;
+    case(PPOPCNT_SSE_HARLEY_SEAL): return pospopcnt_u16_sse_harley_seal;
     case(PPOPCNT_AVX2_POPCNT): return pospopcnt_u16_avx2_popcnt;
     case(PPOPCNT_AVX2): return pospopcnt_u16_avx2;
     case(PPOPCNT_AVX2_POPCNT_NAIVE): return pospopcnt_u16_avx2_naive_counter;
@@ -120,19 +120,19 @@ pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method) {
     case(PPOPCNT_AVX2_BLEND_POPCNT_UR8): return pospopcnt_u16_avx2_blend_popcnt_unroll8;
     case(PPOPCNT_AVX2_BLEND_POPCNT_UR16): return pospopcnt_u16_avx2_blend_popcnt_unroll16;
     case(PPOPCNT_AVX2_ADDER_FOREST): return pospopcnt_u16_avx2_adder_forest;
-    case(PPOPCNT_AVX2_HARVEY_SEAL): return pospopcnt_u16_avx2_harvey_seal;
+    case(PPOPCNT_AVX2_HARLEY_SEAL): return pospopcnt_u16_avx2_harley_seal;
     case(PPOPCNT_AVX512): return pospopcnt_u16_avx512;
     case(PPOPCNT_AVX512BW_MASK32): return pospopcnt_u16_avx512bw_popcnt32_mask;
     case(PPOPCNT_AVX512BW_MASK64): return pospopcnt_u16_avx512bw_popcnt64_mask;
-    case(PPOSCNT_AVX512_MASKED_OPS): return pospopcnt_u16_avx512_masked_ops;
+    case(PPOPCNT_AVX512_MASKED_OPS): return pospopcnt_u16_avx512_masked_ops;
     case(PPOPCNT_AVX512_POPCNT): return pospopcnt_u16_avx512_popcnt;
     case(PPOPCNT_AVX512BW_BLEND_POPCNT): return pospopcnt_u16_avx512bw_blend_popcnt;
     case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR4): return pospopcnt_u16_avx512bw_blend_popcnt_unroll4;
     case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR8): return pospopcnt_u16_avx512bw_blend_popcnt_unroll8;
     case(PPOPCNT_AVX512BW_ADDER_FOREST): return pospopcnt_u16_avx512bw_adder_forest;
     case(PPOPCNT_AVX512_MULA2): return pospopcnt_u16_avx512_mula2;
-    case(PPOPCNT_AVX512BW_HARVEY_SEAL): return pospopcnt_u16_avx512bw_harvey_seal;
-    case(PPOPCNT_AVX512VBMI_HARVEY_SEAL): return pospopcnt_u16_avx512vbmi_harvey_seal;
+    case(PPOPCNT_AVX512BW_HARLEY_SEAL): return pospopcnt_u16_avx512bw_harley_seal;
+    case(PPOPCNT_AVX512VBMI_HARLEY_SEAL): return pospopcnt_u16_avx512vbmi_harley_seal;
     case PPOPCNT_NUMBER_METHODS: break; /* -Wswitch */
     }
     assert(0);
@@ -1534,7 +1534,7 @@ int pospopcnt_u16_avx2_adder_forest(const uint16_t* array, uint32_t len, uint32_
     return 0;
 }
 
-int pospopcnt_u16_avx2_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
+int pospopcnt_u16_avx2_harley_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
     for (uint32_t i = len - (len % (16 * 16)); i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((array[i] & (1 << j)) >> j);
@@ -1844,7 +1844,7 @@ pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll4)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll8)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll16)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_adder_forest)
-pospopcnt_u16_stub(pospopcnt_u16_avx2_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_harley_seal)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 3
@@ -2101,7 +2101,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* array, uint32_t len,
     return 0;
 }
 
-int pospopcnt_u16_sse_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
+int pospopcnt_u16_sse_harley_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
     for (uint32_t i = len - (len % (16 * 8)); i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((array[i] & (1 << j)) >> j);
@@ -2202,7 +2202,7 @@ void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* fla
     for (int i=0; i < 16; i++)
         pospopcnt16[i] = 0;
 
-    pospopcnt_u16_sse_harvey_seal((uint16_t*)data, len/2, pospopcnt16);
+    pospopcnt_u16_sse_harley_seal((uint16_t*)data, len/2, pospopcnt16);
     for (int i=0; i < 8; i++)
         flag_counts[i] = pospopcnt16[i + 0] + pospopcnt16[i + 8];
 
@@ -2249,7 +2249,7 @@ pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt)
 pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll4)
 pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll8)
 pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll16)
-pospopcnt_u16_stub(pospopcnt_u16_sse_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_sse_harley_seal)
 pospopcnt_u8_stub(pospopcnt_u8_sse_harley_seal)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll8)
 #endif
@@ -2624,7 +2624,7 @@ pospopcnt_u16_stub(pospopcnt_u16_avx512bw_adder_forest)
 #endif
 
 #if defined(__AVX512BW__) && __AVX512BW__ == 1
-int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
+int pospopcnt_u16_avx512bw_harley_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
     for (uint32_t i = len - (len % (32 * 16)); i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((array[i] & (1 << j)) >> j);
@@ -2718,11 +2718,11 @@ int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* array, uint32_t len, uint
     }
 }
 #else
-pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harley_seal)
 #endif
 
 #if defined(__AVX512VBMI__) && __AVX512VBMI__ == 1
-int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
+int pospopcnt_u16_avx512vbmi_harley_seal(const uint16_t* array, uint32_t len, uint32_t* flags) {
     for (uint32_t i = len - (len % (32 * 16)); i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((array[i] & (1 << j)) >> j);
@@ -2863,7 +2863,7 @@ int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* array, uint32_t len, ui
     return 0;
 }
 #else
-pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harley_seal)
 #endif
 
 int pospopcnt_u16_avx512_masked_ops(const uint16_t* data, uint32_t len, uint32_t* flags) {
@@ -2878,11 +2878,11 @@ int pospopcnt_u16_avx512_masked_ops(const uint16_t* data, uint32_t len, uint32_t
 }
 
 // Wrapper
-int pospopcnt_u16_avx512_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags) { 
+int pospopcnt_u16_avx512_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags) { 
     #if defined(__AVX512BW__) && __AVX512BW__ == 1
-    return pospopcnt_u16_avx512bw_harvey_seal(data, len, flags);
+    return pospopcnt_u16_avx512bw_harley_seal(data, len, flags);
     #elif defined(__AVX512VBMI__) && __AVX512VBMI__ == 1
-    return pospopcnt_u16_avx512vbmi_harvey_seal(data, len, flags);
+    return pospopcnt_u16_avx512vbmi_harley_seal(data, len, flags);
     #else
     return(0);
     #endif
@@ -2893,8 +2893,8 @@ pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt)
 pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll4)
 pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll8)
 pospopcnt_u16_stub(pospopcnt_u16_avx512bw_adder_forest)
-pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harvey_seal)
-pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harley_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harley_seal)
 pospopcnt_u16_stub(pospopcnt_u16_avx512_mula2)
 pospopcnt_u16_stub(pospopcnt_u16_avx512_masked_ops)
 #endif

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -87,6 +87,7 @@ int pospopcnt_u16_method(PPOPCNT_U16_METHODS method, const uint16_t* data, uint3
     case(PPOPCNT_AVX512_MULA2): return pospopcnt_u16_avx512_mula2(data, len, flags);
     case(PPOPCNT_AVX512BW_HARVEY_SEAL): return pospopcnt_u16_avx512bw_harvey_seal(data, len, flags);
     case(PPOPCNT_AVX512VBMI_HARVEY_SEAL): return pospopcnt_u16_avx512vbmi_harvey_seal(data, len, flags);
+    case PPOPCNT_NUMBER_METHODS: break; /* -Wswitch */
     }
     assert(0);
     return 0; /* unreachable, but some compilers complain without it */
@@ -132,6 +133,7 @@ pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method) {
     case(PPOPCNT_AVX512_MULA2): return pospopcnt_u16_avx512_mula2;
     case(PPOPCNT_AVX512BW_HARVEY_SEAL): return pospopcnt_u16_avx512bw_harvey_seal;
     case(PPOPCNT_AVX512VBMI_HARVEY_SEAL): return pospopcnt_u16_avx512vbmi_harvey_seal;
+    case PPOPCNT_NUMBER_METHODS: break; /* -Wswitch */
     }
     assert(0);
     return 0; /* unreachable, but some compilers complain without it */
@@ -144,6 +146,7 @@ pospopcnt_u8_method_type get_pospopcnt_u8_method(PPOPCNT_U8_METHODS method) {
     case(PPOPCNT_U8_SSE_SAD): return pospopcnt_u8_sse_sad;
     case(PPOPCNT_U8_SSE_BLEND_POPCNT_UR8): return pospopcnt_u8_sse_blend_popcnt_unroll8;
     case(PPOPCNT_U8_SSE_HARLEY_SEAL): return pospopcnt_u8_sse_harley_seal;
+    case PPOPCNT_U8_NUMBER_METHODS: break; /* -Wswitch */
     }
     assert(0);
     return 0; /* unreachable, but some compilers complain without it */

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -157,6 +157,13 @@ void pospopcnt_u8_scalar_naive(const uint8_t* data, size_t len, uint32_t* out) {
     }
 }
 
+#define pospopcnt_u16_stub(name) \
+    int name(const uint16_t* data, uint32_t len, uint32_t* flags) { (void)data; (void)len; (void)flags; return(0); }
+
+#define pospopcnt_u8_stub(name) \
+    void name(const uint8_t* data, size_t len, uint32_t* flags) { (void)data; (void)len; (void)flags; return(0); }
+
+
 void pospopcnt_u8_scalar_naive_single(uint8_t data, uint32_t* out) {
     for (int i = 0; i < 8; ++i)
         out[i] += ((data & (1 << i)) >> i);
@@ -406,10 +413,10 @@ int pospopcnt_u16_avx2_single(const uint16_t* data, uint32_t len, uint32_t* flag
     return 0;
 }
 #else
-int pospopcnt_u16_avx2_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_naive_counter(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_single(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx2_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_avx2)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_naive_counter)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_single)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 3
@@ -682,9 +689,9 @@ void pospopcnt_u8_sse_sad(const uint8_t* data, size_t len, uint32_t* flag_counts
         pospopcnt_u8_scalar_naive_single(data[len - 1], flag_counts);
 }
 #else
-int pospopcnt_u16_sse_single(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_sse_sad(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-void pospopcnt_u8_sse_sad(const uint8_t* data, size_t len, uint32_t* flag_counts) {}
+pospopcnt_u16_stub(pospopcnt_u16_sse_single)
+pospopcnt_u16_stub(pospopcnt_u16_sse_sad)
+pospopcnt_u8_stub(pospopcnt_u8_sse_sad)
 #endif
 
 #if !defined(__clang__) && !defined(_MSC_VER)
@@ -938,9 +945,9 @@ void pospopcnt_u8_scalar_umul128_unroll2(const uint8_t* data, size_t len, uint32
         pospopcnt_u8_scalar_naive_single(data[len - 1], flag_counts);
 }
 #else 
-int pospopcnt_u16_scalar_umul128(const uint16_t* in, uint32_t n, uint32_t* out) { return(0); }
-int pospopcnt_u16_scalar_umul128_unroll2(const uint16_t* in, uint32_t n, uint32_t* out) { return(0); }
-void pospopcnt_u8_scalar_umul128_unroll2(const uint8_t* data, size_t len, uint32_t* flag_counts) {}
+pospopcnt_u16_stub(pospopcnt_u16_scalar_umul128)
+pospopcnt_u16_stub(pospopcnt_u16_scalar_umul128_unroll2)
+pospopcnt_u8_stub(pospopcnt_u8_scalar_umul128_unroll2)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 6
@@ -1021,8 +1028,8 @@ int pospopcnt_u16_avx512bw_popcnt64_mask(const uint16_t* data, uint32_t len, uin
     return 0;
 }
 #else
-int pospopcnt_u16_avx512bw_popcnt32_mask(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_popcnt64_mask(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_popcnt32_mask)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_popcnt64_mask)
 #endif
 
 int pospopcnt_u16_avx512_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) {
@@ -1139,10 +1146,10 @@ int pospopcnt_u16_avx512(const uint16_t* data, uint32_t len, uint32_t* flags) {
 }
 
 #else
-int pospopcnt_u16_avx512bw_popcnt32_mask(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_popcnt64_mask(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_popcnt32_mask)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_popcnt64_mask)
+pospopcnt_u16_stub(pospopcnt_u16_avx512_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_avx512)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 5
@@ -1827,14 +1834,14 @@ int pospopcnt_u16_avx2_blend_popcnt_unroll16(const uint16_t* array, uint32_t len
     return 0;
 }
 #else
-int pospopcnt_u16_avx2_lemire(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_lemire2(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_blend_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_adder_forest(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx2_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx2_lemire)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_lemire2)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll4)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll8)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll16)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_adder_forest)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_harvey_seal)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 3
@@ -2238,13 +2245,13 @@ uint64_t sse4_sum_epu64(__m128i x) {
 }
 
 #else
-int pospopcnt_u16_sse_blend_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_sse_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_sse_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_sse_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* flag_counts) {}
-void pospopcnt_u8_sse_blend_popcnt_unroll8(const uint8_t* data, size_t len, uint32_t* flag_counts) {}
+pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll4)
+pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll8)
+pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll16)
+pospopcnt_u16_stub(pospopcnt_u16_sse_harvey_seal)
+pospopcnt_u8_stub(pospopcnt_u8_sse_harley_seal)
+pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll8)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 6
@@ -2407,9 +2414,9 @@ int pospopcnt_u16_avx512bw_blend_popcnt_unroll8(const uint16_t* data, uint32_t l
     return 0;
 }
 #else 
-int pospopcnt_u16_avx512bw_blend_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll4)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll8)
 #endif
 
 int pospopcnt_u16_avx512_mula2(const uint16_t* data, uint32_t len, uint32_t* flags) {
@@ -2615,7 +2622,7 @@ int pospopcnt_u16_avx512bw_adder_forest(const uint16_t* array, uint32_t len, uin
     return 0;
 }
 #else
-int pospopcnt_u16_avx512bw_adder_forest(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_adder_forest)
 #endif
 
 #if defined(__AVX512BW__) && __AVX512BW__ == 1
@@ -2713,7 +2720,7 @@ int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* array, uint32_t len, uint
     }
 }
 #else
-int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harvey_seal)
 #endif
 
 #if defined(__AVX512VBMI__) && __AVX512VBMI__ == 1
@@ -2858,7 +2865,7 @@ int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* array, uint32_t len, ui
     return 0;
 }
 #else
-int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harvey_seal)
 #endif
 
 int pospopcnt_u16_avx512_masked_ops(const uint16_t* data, uint32_t len, uint32_t* flags) {
@@ -2884,14 +2891,14 @@ int pospopcnt_u16_avx512_harvey_seal(const uint16_t* data, uint32_t len, uint32_
 }
 #undef AND_OR
 #else
-int pospopcnt_u16_avx512bw_blend_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_adder_forest(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512_mula2(const uint16_t* array, uint32_t len, uint32_t* flags) { return(0); }
-int pospopcnt_u16_avx512_masked_ops(const uint16_t* data, uint32_t len, uint32_t* flags) { return(0); }
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll4)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_blend_popcnt_unroll8)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_adder_forest)
+pospopcnt_u16_stub(pospopcnt_u16_avx512bw_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512vbmi_harvey_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx512_mula2)
+pospopcnt_u16_stub(pospopcnt_u16_avx512_masked_ops)
 #endif
 
 #if __clang__ == 1 || __llvm__ == 1

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -153,7 +153,7 @@ pospopcnt_u8_method_type get_pospopcnt_u8_method(PPOPCNT_U8_METHODS method) {
 }
 
 void pospopcnt_u8_scalar_naive(const uint8_t* data, size_t len, uint32_t* out) {
-    for (int i = 0; i < len; ++i) {
+    for (size_t i = 0; i < len; ++i) {
         for (int j = 0; j < 8; ++j) {
             out[j] += ((data[i] & (1 << j)) >> j);
         }
@@ -450,7 +450,7 @@ int pospopcnt_u16_sse_single(const uint16_t* data, uint32_t len, uint32_t* flags
 #define UL(idx) out_counters[idx] += _mm_extract_epi16(counterHi, idx);
 
     uint32_t pos = 0;
-    for (int i = 0; i < n_update_cycles; ++i) { // each block of 65536 values
+    for (size_t i = 0; i < n_update_cycles; ++i) { // each block of 65536 values
         for (int k = 0; k < 4096; ++k, ++pos) { // max sum of each 16-bit value in a register (65536/16)
             BLOCK
         }
@@ -472,7 +472,7 @@ int pospopcnt_u16_sse_single(const uint16_t* data, uint32_t len, uint32_t* flags
 #undef UPDATE_LO
 
     // residual
-    for (int i = pos*8; i < len; ++i) {
+    for (size_t i = pos*8; i < len; ++i) {
         for (int j = 0; j < 16; ++j)
             out_counters[j] += ((data[i] & (1 << j)) >> j);
     }
@@ -701,7 +701,7 @@ pospopcnt_u8_stub(pospopcnt_u8_sse_sad)
 __attribute__((optimize("no-tree-vectorize")))
 #endif
 int pospopcnt_u16_scalar_naive_nosimd(const uint16_t* data, uint32_t len, uint32_t* flags) {
-    for (int i = 0; i < len; ++i) {
+    for (uint32_t i = 0; i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((data[i] & (1 << j)) >> j);
         }
@@ -711,7 +711,7 @@ int pospopcnt_u16_scalar_naive_nosimd(const uint16_t* data, uint32_t len, uint32
 }
 
 int pospopcnt_u16_scalar_naive(const uint16_t* data, uint32_t len, uint32_t* flags) {
-    for (int i = 0; i < len; ++i) {
+    for (uint32_t i = 0; i < len; ++i) {
         for (int j = 0; j < 16; ++j) {
             flags[j] += ((data[i] & (1 << j)) >> j);
         }
@@ -723,7 +723,7 @@ int pospopcnt_u16_scalar_naive(const uint16_t* data, uint32_t len, uint32_t* fla
 int pospopcnt_u16_scalar_partition(const uint16_t* data, uint32_t len, uint32_t* flags) {
     uint32_t low[256] = {0}, high[256] = {0};
 
-    for (int i = 0; i < len; ++i) {
+    for (uint32_t i = 0; i < len; ++i) {
         ++low[data[i] & 255];
         ++high[(data[i] >> 8) & 255];
     }
@@ -746,7 +746,7 @@ int pospopcnt_u16_scalar_partition(const uint16_t* data, uint32_t len, uint32_t*
 int pospopcnt_u16_scalar_hist1x4(const uint16_t* data, uint32_t len, uint32_t* flags) {
      uint32_t low[256] = {0}, high[256] = {0};
 
-     int i = 0;
+     uint32_t i = 0;
      for (i = 0; i < (len & ~3); i+=4) {
           ++low[data[i+0] & 255];
           ++high[(data[i+0] >> 8) & 255];
@@ -2201,8 +2201,8 @@ int pospopcnt_u16_sse_harvey_seal(const uint16_t* array, uint32_t len, uint32_t*
 }
 
 void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* flag_counts) {
-    uint32_t pospopcnt16[32];
-    for (int i=0; i < 32; i++)
+    uint32_t pospopcnt16[16];
+    for (int i=0; i < 16; i++)
         pospopcnt16[i] = 0;
 
     pospopcnt_u16_sse_harvey_seal((uint16_t*)data, len/2, pospopcnt16);

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -1855,7 +1855,7 @@ int pospopcnt_u16_sse_blend_popcnt(const uint16_t* array, uint32_t len, uint32_t
         __m128i v1 = _mm_loadu_si128(data_vectors + i + 1);
 
         __m128i input0 = _mm_or_si128(_mm_and_si128(v0, _mm_set1_epi16(0x00FF)), _mm_slli_epi16(v1, 8));
-        __m128i input1 = _mm_or_si128(_mm_and_si128(v0, _mm_set1_epi16(0xFF00)), _mm_srli_epi16(v1, 8));
+        __m128i input1 = _mm_or_si128(_mm_and_si128(v0, _mm_set1_epi16((int16_t)0xFF00)), _mm_srli_epi16(v1, 8));
         
         for (int i = 0; i < 8; ++i) {
             flags[ 7 - i] += _mm_popcnt_u32(_mm_movemask_epi8(input0));
@@ -1885,7 +1885,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll4(const uint16_t* array, uint32_t len, 
         L(0) L(1) L(2) L(3)
 
 #define U0(p,k) __m128i input##p = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0x00FF)), _mm_slli_epi16(v##k, 8));
-#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0xFF00)), _mm_srli_epi16(v##k, 8));
+#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16((int16_t)0xFF00)), _mm_srli_epi16(v##k, 8));
 #define U(p, k)  U0(p,k) U1(p,k)
 
         U(0,1) U(2,3)
@@ -1957,7 +1957,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll8(const uint16_t* array, uint32_t len, 
         L(4) L(5) L(6) L(7)
 
 #define U0(p,k) __m128i input##p = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0x00FF)), _mm_slli_epi16(v##k, 8));
-#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0xFF00)), _mm_srli_epi16(v##k, 8));
+#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16((int16_t)0xFF00)), _mm_srli_epi16(v##k, 8));
 #define U(p, k)  U0(p,k) U1(p,k)
 
         U(0,1) U(2,3) U(4,5) U(6,7)
@@ -2028,7 +2028,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* array, uint32_t len,
         L(12) L(13) L(14) L(15)
 
 #define U0(p,k) __m128i input##p = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0x00FF)), _mm_slli_epi16(v##k, 8));
-#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16(0xFF00)), _mm_srli_epi16(v##k, 8));
+#define U1(p,k) __m128i input##k = _mm_or_si128(_mm_and_si128(v##p, _mm_set1_epi16((int16_t)0xFF00)), _mm_srli_epi16(v##k, 8));
 #define U(p, k)  U0(p,k) U1(p,k)
 
         U(0,1) U( 2, 3) U( 4, 5) U( 6, 7)
@@ -2212,8 +2212,8 @@ void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* fla
 
 
 __m128i sse4_merge1_odd(__m128i a, __m128i b) {
-    const __m128i t0 = a & _mm_set1_epi8(0xaa);
-    const __m128i t1 = b & _mm_set1_epi8(0xaa);
+    const __m128i t0 = a & _mm_set1_epi8((int8_t)0xaa);
+    const __m128i t1 = b & _mm_set1_epi8((int8_t)0xaa);
 
     return t0 | (_mm_srli_epi32(t1, 1));
 }
@@ -2226,8 +2226,8 @@ __m128i sse4_merge1_even(__m128i a, __m128i b) {
 }
 
 __m128i sse4_merge2_odd(__m128i a, __m128i b) {
-    const __m128i t0 = a & _mm_set1_epi8(0xcc);
-    const __m128i t1 = b & _mm_set1_epi8(0xcc);
+    const __m128i t0 = a & _mm_set1_epi8((int8_t)0xcc);
+    const __m128i t1 = b & _mm_set1_epi8((int8_t)0xcc);
 
     return t0 | (_mm_srli_epi32(t1, 2));
 }
@@ -2267,7 +2267,7 @@ int pospopcnt_u16_avx512bw_blend_popcnt(const uint16_t* data, uint32_t len, uint
         __m512i v1 = _mm512_loadu_si512(data_vectors + i + 1);
 
         __m512i input0 = _mm512_ternarylogic_epi32(v0, _mm512_set1_epi16(0x00FF), _mm512_slli_epi16(v1, 8), AND_OR);
-        __m512i input1 = _mm512_ternarylogic_epi32(v0, _mm512_set1_epi16(0xFF00), _mm512_srli_epi16(v1, 8), AND_OR);
+        __m512i input1 = _mm512_ternarylogic_epi32(v0, _mm512_set1_epi16((int16_t)0xFF00), _mm512_srli_epi16(v1, 8), AND_OR);
         
         for (int i = 0; i < 8; ++i) {
             flags[ 7 - i] += _mm_popcnt_u64(_mm512_movepi8_mask(input0));

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -40,7 +40,7 @@
  * | sse_blend_popcnt_unroll8    | 2.09 | 3.16 | 2.35 | 1.88 | 1.67 | 1.56 | 1.5  | 1.44  |
  * | avx512_blend_popcnt_unroll8 | 1.78 | 3.61 | 3.61 | 3.59 | 3.68 | 3.65 | 3.67 | 3.7   |
  * | avx512_adder_forest         | 0.77 | 0.9  | 3.24 | 3.96 | 4.96 | 5.87 | 6.52 | 7.24  |
- * | avx512_harvey_seal          | 0.52 | 0.74 | 1.83 | 2.64 | 4.06 | 6.43 | 9.41 | 16.28 |
+ * | avx512_harley_seal          | 0.52 | 0.74 | 1.83 | 2.64 | 4.06 | 6.43 | 9.41 | 16.28 |
  * 
  * Compared to a naive unvectorized solution (`pospopcnt_u16_scalar_naive_nosimd`):
  * 
@@ -49,7 +49,7 @@
  * | sse_mula_unroll8            | 8.28 | 9.84  | 10.55 | 11    | 11.58 | 11.93 | 12.13 | 12.28  |
  * | avx512_blend_popcnt_unroll8 | 7.07 | 11.25 | 16.21 | 21    | 25.49 | 27.91 | 29.73 | 31.55  |
  * | avx512_adder_forest         | 3.05 | 2.82  | 14.53 | 23.13 | 34.37 | 44.91 | 52.78 | 61.68  |
- * | avx512_harvey_seal          | 2.07 | 2.3   | 8.21  | 15.41 | 28.17 | 49.14 | 76.11 | 138.71 |
+ * | avx512_harley_seal          | 2.07 | 2.3   | 8.21  | 15.41 | 28.17 | 49.14 | 76.11 | 138.71 |
  * 
 */
 #ifndef POSPOPCNT_H_2359235897293
@@ -247,7 +247,7 @@ typedef enum {
     PPOPCNT_SSE_BLEND_POPCNT_UR8,
     PPOPCNT_SSE_BLEND_POPCNT_UR16,
     PPOPCNT_SSE_SAD,
-    PPOPCNT_SSE_HARVEY_SEAL,
+    PPOPCNT_SSE_HARLEY_SEAL,
     PPOPCNT_AVX2_POPCNT,
     PPOPCNT_AVX2,
     PPOPCNT_AVX2_POPCNT_NAIVE,
@@ -259,19 +259,19 @@ typedef enum {
     PPOPCNT_AVX2_BLEND_POPCNT_UR8,
     PPOPCNT_AVX2_BLEND_POPCNT_UR16,
     PPOPCNT_AVX2_ADDER_FOREST,
-    PPOPCNT_AVX2_HARVEY_SEAL,
+    PPOPCNT_AVX2_HARLEY_SEAL,
     PPOPCNT_AVX512,
     PPOPCNT_AVX512BW_MASK32,
     PPOPCNT_AVX512BW_MASK64,
-    PPOSCNT_AVX512_MASKED_OPS,
+    PPOPCNT_AVX512_MASKED_OPS,
     PPOPCNT_AVX512_POPCNT,
     PPOPCNT_AVX512BW_BLEND_POPCNT,
     PPOPCNT_AVX512BW_BLEND_POPCNT_UR4,
     PPOPCNT_AVX512BW_BLEND_POPCNT_UR8,
     PPOPCNT_AVX512_MULA2,
     PPOPCNT_AVX512BW_ADDER_FOREST,
-    PPOPCNT_AVX512BW_HARVEY_SEAL,
-    PPOPCNT_AVX512VBMI_HARVEY_SEAL,
+    PPOPCNT_AVX512BW_HARLEY_SEAL,
+    PPOPCNT_AVX512VBMI_HARLEY_SEAL,
     //
     PPOPCNT_NUMBER_METHODS
 } PPOPCNT_U16_METHODS;
@@ -290,7 +290,7 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_sse_blend_popcnt_unroll8",
     "pospopcnt_u16_sse_blend_popcnt_unroll16",
     "pospopcnt_u16_sse2_sad",
-    "pospopcnt_u16_sse2_harvey_seal",
+    "pospopcnt_u16_sse2_harley_seal",
     "pospopcnt_u16_avx2_popcnt",
     "pospopcnt_u16_avx2",
     "pospopcnt_u16_avx2_naive_counter",
@@ -302,7 +302,7 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_avx2_blend_popcnt_unroll8",
     "pospopcnt_u16_avx2_blend_popcnt_unroll16",
     "pospopcnt_u16_avx2_adder_forest",
-    "pospopcnt_u16_avx2_harvey_seal",
+    "pospopcnt_u16_avx2_harley_seal",
     "pospopcnt_u16_avx512",
     "pospopcnt_u16_avx512bw_popcnt32_mask",
     "pospopcnt_u16_avx512bw_popcnt64_mask",
@@ -313,8 +313,8 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_avx512bw_blend_popcnt_unroll8",
     "pospopcnt_u16_avx512_mula2",
     "pospopcnt_u16_avx512bw_adder_forest",
-    "pospopcnt_u16_avx512bw_harvey_seal",
-    "pospopcnt_u16_avx512vbmi_harvey_seal"};
+    "pospopcnt_u16_avx512bw_harley_seal",
+    "pospopcnt_u16_avx512vbmi_harley_seal"};
 
 typedef enum {
     PPOPCNT_U8_SCALAR,
@@ -376,7 +376,7 @@ int pospopcnt_u16_method(PPOPCNT_U16_METHODS method, const uint16_t* data, uint3
  * 
  * Example usage:
  * 
- * pospopcnt_u16_method_type f = get_pospopcnt_u16_method(PPOPCNT_AVX2_HARVEY_SEAL);
+ * pospopcnt_u16_method_type f = get_pospopcnt_u16_method(PPOPCNT_AVX2_HARLEY_SEAL);
  * (*f)(data, len, flags);
  * 
  * @param method                     Target function (PPOPCNT_U16_METHODS).
@@ -395,7 +395,7 @@ pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method);
 *  before calling pospopcnt_u16_* the first time.
 *
 *  Function names are prefixed by its target instruction set: 
-*  [scalar, sse, avx2, avx512]. For example, pospopcnt_u16_avx2_harvey_seal.
+*  [scalar, sse, avx2, avx512]. For example, pospopcnt_u16_avx2_harley_seal.
 ************************************************************************/
 int pospopcnt_u16_scalar_naive(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_scalar_naive_nosimd(const uint16_t* data, uint32_t len, uint32_t* flags);
@@ -409,7 +409,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, u
 int pospopcnt_u16_sse_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_sse_sad(const uint16_t* data, uint32_t len, uint32_t* flags);
-int pospopcnt_u16_sse_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_sse_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_naive_counter(const uint16_t* data, uint32_t len, uint32_t* flags);
@@ -422,7 +422,7 @@ int pospopcnt_u16_avx2_adder_forest(const uint16_t* data, uint32_t len, uint32_t
 int pospopcnt_u16_avx2_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags);
-int pospopcnt_u16_avx2_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_avx2_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512bw_popcnt32_mask(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512bw_popcnt64_mask(const uint16_t* data, uint32_t len, uint32_t* flags);
@@ -433,15 +433,15 @@ int pospopcnt_u16_avx512bw_blend_popcnt_unroll4(const uint16_t* data, uint32_t l
 int pospopcnt_u16_avx512bw_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512_mula2(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512bw_adder_forest(const uint16_t* data, uint32_t len, uint32_t* flags);
-int pospopcnt_u16_avx512bw_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
-int pospopcnt_u16_avx512vbmi_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_avx512bw_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_avx512vbmi_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
 
 /**
  * @brief Retrieve the target pospopcnt_u8_method pointer.
  * 
  * Example usage:
  * 
- * pospopcnt_u8_method_type f = get_pospopcnt_u16_method(PPOPCNT8_AVX2_HARVEY_SEAL);
+ * pospopcnt_u8_method_type f = get_pospopcnt_u16_method(PPOPCNT8_AVX2_HARLEY_SEAL);
  * (*f)(data, len, flags);
  * 
  * @param method                     Target function (PPOPCNT_U8_METHODS).
@@ -457,8 +457,8 @@ void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* fla
 void pospopcnt_u8_sse_variant1(const uint8_t* data, size_t len, uint32_t* flag_counts);
 
 /*======   Support   ======*/
-// Wrapper for avx512*_harvey_seal
-int pospopcnt_u16_avx512_harvey_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+// Wrapper for avx512*_harley_seal
+int pospopcnt_u16_avx512_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR resolves all warnings reported by GCC 9 for `-Wall -Wextra`.