### PR TITLE
Pospopcnt for 8-bit data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # under the License.
 ###################################################################
 
-OPTFLAGS  := -O3 -march=native
+OPTFLAGS  := -O3 -march=native # -march=cannonlake 
 WARNFLAGS := # -Wall -Wextra -pedantic
 CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 ###################################################################
 
 OPTFLAGS  := -O3 -march=native
-WARNFLAGS := # -Wall -Wextra -pedantic
+WARNFLAGS := -Wall -Wextra -pedantic
 CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPP_SOURCE = benchmark.cpp benchmark/linux/instrumented_benchmark.cpp

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 ###################################################################
 
 OPTFLAGS  := -O3 -march=native
-WARNFLAGS := -Wall -Wextra -pedantic
+WARNFLAGS := # -Wall -Wextra -pedantic
 CFLAGS     = -std=c99 $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPPFLAGS   = -std=c++0x $(OPTFLAGS) $(DEBUG_FLAGS) $(WARNFLAGS)
 CPP_SOURCE = benchmark.cpp benchmark/linux/instrumented_benchmark.cpp

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -17,6 +17,7 @@
 #include "pospopcnt.h"
 
 inline void* aligned_malloc(size_t size, size_t align) {
+    (void)align;
     void* result;
 #if __STDC_VERSION__ >= 201112L
     result = aligned_alloc(align, size);
@@ -50,7 +51,7 @@ uint64_t get_cpu_cycles() {
     result = __rdtsc();
 #endif
     return result;
-};
+}
 
 bool assert_truth(uint32_t* vals, uint32_t* truth) {
     uint64_t n_all = 0;
@@ -89,7 +90,7 @@ void generate_random_data(IntegerType* data, size_t n) {
 
     std::uniform_int_distribution<uint32_t> distr(0, std::numeric_limits<IntegerType>::max()-1); // right inclusive
 
-    for (int i = 0; i < n; ++i) {
+    for (size_t i = 0; i < n; ++i) {
         data[i] = distr(eng);
     }
 }
@@ -168,7 +169,6 @@ public:
 
 template <typename pospopcnt_function_type, typename ItemType>
 Measurement pospopcnt_wrapper(
-    const char* method_name,
     pospopcnt_function_type measured_function,
     pospopcnt_function_type reference_function,
     int iterations,
@@ -257,9 +257,9 @@ struct Parameters {
 };
 
 class MeasurementsPrinter {
+    std::ostream& out;
     bool header_printed = false;
     bool only_time;
-    std::ostream& out;
     
 public:
     MeasurementsPrinter(std::ostream& out, bool only_time)
@@ -318,7 +318,7 @@ void benchmark(uint16_t* vals, const Parameters& params) {
         auto method = get_pospopcnt_u16_method(PPOPCNT_U16_METHODS(i));
         auto reference = pospopcnt_u16_scalar_naive;
         const auto meas = pospopcnt_wrapper<pospopcnt_u16_method_type, uint16_t>(
-            name, method, reference, params.iterations, vals, params.items_count);
+            method, reference, params.iterations, vals, params.items_count);
 
         printer.print(name, meas);
     }
@@ -330,7 +330,7 @@ void benchmark(uint16_t* vals, const Parameters& params) {
         auto method = get_pospopcnt_u8_method(PPOPCNT_U8_METHODS(i));
         auto reference = pospopcnt_u8_scalar_naive;
         const auto meas = pospopcnt_wrapper<pospopcnt_u8_method_type, uint8_t>(
-            name, method, reference, params.iterations, (uint8_t*)vals, params.items_count);
+            method, reference, params.iterations, (uint8_t*)vals, params.items_count);
 
         printer.print(name, meas);
     }

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -155,6 +155,7 @@ pospopcnt_u8_method_type get_pospopcnt_u8_method(PPOPCNT_U8_METHODS method) {
     case PPOPCNT_U8_SSE_BLEND_POPCNT_UR16: return pospopcnt_u8_sse_blend_popcnt_unroll16;
     case PPOPCNT_U8_SSE_SAD: return pospopcnt_u8_sse_sad;
     case PPOPCNT_U8_SSE_HARLEY_SEAL: return pospopcnt_u8_sse_harley_seal;
+    case PPOPCNT_U8_SSE_POPCNT4BIT: return pospopcnt_u8_sse_popcnt4bit;
     case PPOPCNT_U8_AVX2_POPCNT: return pospopcnt_u8_avx2_popcnt;
     case PPOPCNT_U8_AVX2: return pospopcnt_u8_avx2;
     case PPOPCNT_U8_AVX2_POPCNT_NAIVE: return pospopcnt_u8_avx2_naive_counter;
@@ -2254,6 +2255,7 @@ int pospopcnt_u16_sse_harley_seal(const uint16_t* array, uint32_t len, uint32_t*
     return 0;
 }
 
+static
 __m128i sse4_merge1_odd(__m128i a, __m128i b) {
     const __m128i t0 = a & _mm_set1_epi8((int8_t)0xaa);
     const __m128i t1 = b & _mm_set1_epi8((int8_t)0xaa);
@@ -2261,11 +2263,146 @@ __m128i sse4_merge1_odd(__m128i a, __m128i b) {
     return t0 | (_mm_srli_epi32(t1, 1));
 }
 
+static
 __m128i sse4_merge1_even(__m128i a, __m128i b) {
     const __m128i t0 = a & _mm_set1_epi8(0x55);
     const __m128i t1 = b & _mm_set1_epi8(0x55);
 
     return t0 | (_mm_add_epi8(t1, t1));
+}
+
+static
+__m128i sse4_merge2_odd(__m128i a, __m128i b) {
+    const __m128i t0 = a & _mm_set1_epi8((int8_t)0xcc);
+    const __m128i t1 = b & _mm_set1_epi8((int8_t)0xcc);
+
+    return t0 | (_mm_srli_epi32(t1, 2));
+}
+
+static
+__m128i sse4_merge2_even(__m128i a, __m128i b) {
+    const __m128i t0 = a & _mm_set1_epi8(0x33);
+    const __m128i t1 = b & _mm_set1_epi8(0x33);
+
+    return t0 | (_mm_slli_epi32(t1, 2));
+}
+
+static
+uint64_t sse4_sum_epu64(__m128i x) {
+    return (uint64_t)_mm_extract_epi64(x, 0)
+         + (uint64_t)_mm_extract_epi64(x, 1);
+}
+
+void pospopcnt_u8_sse_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flag_counts) {
+    const __m128i zero = _mm_setzero_si128();
+
+    __m128i counter_a = zero;
+    __m128i counter_b = zero;
+    __m128i counter_c = zero;
+    __m128i counter_d = zero;
+    __m128i counter_e = zero;
+    __m128i counter_f = zero;
+    __m128i counter_g = zero;
+    __m128i counter_h = zero;
+
+    const __m128i popcnt_4bit = _mm_setr_epi8(
+        /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
+        /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
+        /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
+        /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4
+    );
+
+    const __m128i lo_nibble = _mm_set1_epi8(0x0f);
+
+    int local = 0;
+    __m128i counter8bit_a = zero;
+    __m128i counter8bit_b = zero;
+    __m128i counter8bit_c = zero;
+    __m128i counter8bit_d = zero;
+    __m128i counter8bit_e = zero;
+    __m128i counter8bit_f = zero;
+    __m128i counter8bit_g = zero;
+    __m128i counter8bit_h = zero;
+
+    for (const uint8_t* end = &data[(len & ~63)]; data != end; data += 64) {
+        // r0 = [a0|b0|c0|d0|e0|f0|g0|h0]
+        // r1 = [a1|b1|c1|d1|e1|f1|g1|h1]
+        // r2 = [a2|b2|c2|d2|e2|f2|g2|h2]
+        // r3 = [a3|b3|c3|d3|e3|f3|g3|h3]
+        const __m128i r0 = _mm_loadu_si128((__m128i*)&data[0*16]);
+        const __m128i r1 = _mm_loadu_si128((__m128i*)&data[1*16]);
+        const __m128i r2 = _mm_loadu_si128((__m128i*)&data[2*16]);
+        const __m128i r3 = _mm_loadu_si128((__m128i*)&data[3*16]);
+
+        // s0 = [a0|a1|c0|c1|e0|e1|g0|g1]
+        // s1 = [b0|b1|d0|d1|f0|f1|h0|h1]
+        // s2 = [a2|a3|c2|c3|e2|e3|g2|g3]
+        // s3 = [b2|b3|d2|d3|f2|f3|h2|h3]
+        const __m128i s0 = sse4_merge1_even(r0, r1);
+        const __m128i s1 = sse4_merge1_odd (r0, r1);
+        const __m128i s2 = sse4_merge1_even(r2, r3);
+        const __m128i s3 = sse4_merge1_odd (r2, r3);
+
+        // d0 = [a0|a1|a2|a3|e0|e1|e2|e3]
+        // d1 = [b0|b1|b2|b3|f0|f1|f2|f3]
+        // d2 = [c0|c1|c2|c3|g0|g1|g2|g3]
+        // d3 = [d0|d1|d2|d3|h0|h1|h2|h3]
+        const __m128i d0 = sse4_merge2_even(s0, s2);
+        const __m128i d1 = sse4_merge2_even(s1, s3);
+        const __m128i d2 = sse4_merge2_odd (s0, s2);
+        const __m128i d3 = sse4_merge2_odd (s1, s3);
+
+        // popcnt for 4-bit subwords in each registers
+        const __m128i popcnt_a = _mm_shuffle_epi8(popcnt_4bit, d0 & lo_nibble);
+        const __m128i popcnt_e = _mm_shuffle_epi8(popcnt_4bit, _mm_srli_epi32(d0, 4) & lo_nibble);
+        const __m128i popcnt_b = _mm_shuffle_epi8(popcnt_4bit, d1 & lo_nibble);
+        const __m128i popcnt_f = _mm_shuffle_epi8(popcnt_4bit, _mm_srli_epi32(d1, 4) & lo_nibble);
+        const __m128i popcnt_c = _mm_shuffle_epi8(popcnt_4bit, d2 & lo_nibble);
+        const __m128i popcnt_g = _mm_shuffle_epi8(popcnt_4bit, _mm_srli_epi32(d2, 4) & lo_nibble);
+        const __m128i popcnt_d = _mm_shuffle_epi8(popcnt_4bit, d3 & lo_nibble);
+        const __m128i popcnt_h = _mm_shuffle_epi8(popcnt_4bit, _mm_srli_epi32(d3, 4) & lo_nibble);
+
+        counter8bit_a = _mm_add_epi8(counter8bit_a, popcnt_a);
+        counter8bit_b = _mm_add_epi8(counter8bit_b, popcnt_b);
+        counter8bit_c = _mm_add_epi8(counter8bit_c, popcnt_c);
+        counter8bit_d = _mm_add_epi8(counter8bit_d, popcnt_d);
+        counter8bit_e = _mm_add_epi8(counter8bit_e, popcnt_e);
+        counter8bit_f = _mm_add_epi8(counter8bit_f, popcnt_f);
+        counter8bit_g = _mm_add_epi8(counter8bit_g, popcnt_g);
+        counter8bit_h = _mm_add_epi8(counter8bit_h, popcnt_h);
+
+        local += 1;
+        if (local == 63) {
+            // avoid overflows in the 8-bit counters
+#define U(n) \
+            counter_##n = _mm_add_epi64(counter_##n, _mm_sad_epu8(counter8bit_##n, zero)); \
+            counter8bit_##n = _mm_setzero_si128();
+
+            U(a) U(b) U(c) U(d)
+            U(e) U(f) U(g) U(h)
+#undef U
+            local = 0;
+        }
+    }
+
+    if (local != 0) {
+#define U(n) counter_##n = _mm_add_epi64(counter_##n, _mm_sad_epu8(counter8bit_##n, zero));
+        U(a) U(b) U(c) U(d)
+        U(e) U(f) U(g) U(h)
+#undef U
+    }
+
+    flag_counts[0] += sse4_sum_epu64(counter_a);
+    flag_counts[1] += sse4_sum_epu64(counter_b);
+    flag_counts[2] += sse4_sum_epu64(counter_c);
+    flag_counts[3] += sse4_sum_epu64(counter_d);
+    flag_counts[4] += sse4_sum_epu64(counter_e);
+    flag_counts[5] += sse4_sum_epu64(counter_f);
+    flag_counts[6] += sse4_sum_epu64(counter_g);
+    flag_counts[7] += sse4_sum_epu64(counter_h);
+
+    // scalar tail loop
+    pospopcnt_u8_scalar_naive(data, len % 64, flag_counts);
 }
 
 make_pospopcnt_u8_from_u16(pospopcnt_u8_sse_blend_popcnt, pospopcnt_u16_sse_blend_popcnt)
@@ -2284,6 +2421,7 @@ pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll4)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll8)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll16)
 pospopcnt_u8_stub(pospopcnt_u8_sse_harley_seal)
+pospopcnt_u8_stub(pospopcnt_u8_sse_popcnt4bit)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 6

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -356,6 +356,7 @@ typedef enum {
     PPOPCNT_U8_AVX512_MULA2,
     PPOPCNT_U8_AVX512BW_ADDER_FOREST,
     PPOPCNT_U8_AVX512BW_HARLEY_SEAL,
+    PPOPCNT_U8_AVX512BW_POPCNT4BIT,
     PPOPCNT_U8_AVX512VBMI_HARLEY_SEAL,
     //
     PPOPCNT_U8_NUMBER_METHODS
@@ -401,6 +402,7 @@ static const char * const pospopcnt_u8_method_names[] = {
     "pospopcnt_u8_avx512_mula2",
     "pospopcnt_u8_avx512bw_adder_forest",
     "pospopcnt_u8_avx512bw_harley_seal",
+    "pospopcnt_u8_avx512bw_popcnt4bit",
     "pospopcnt_u8_avx512vbmi_harley_seal"};
 /*-**********************************************************************
 *  This section contains the higher level functions for computing the
@@ -558,6 +560,7 @@ void pospopcnt_u8_avx512bw_blend_popcnt_unroll8(const uint8_t* data, size_t len,
 void pospopcnt_u8_avx512_mula2(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_adder_forest(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
+void pospopcnt_u8_avx512bw_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512vbmi_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
 
 /*======   Support   ======*/

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -344,6 +344,7 @@ typedef enum {
     PPOPCNT_U8_AVX2_BLEND_POPCNT_UR16,
     PPOPCNT_U8_AVX2_ADDER_FOREST,
     PPOPCNT_U8_AVX2_HARLEY_SEAL,
+    PPOPCNT_U8_AVX2_POPCNT4BIT,
     PPOPCNT_U8_AVX512,
     PPOPCNT_U8_AVX512BW_MASK32,
     PPOPCNT_U8_AVX512BW_MASK64,
@@ -388,6 +389,7 @@ static const char * const pospopcnt_u8_method_names[] = {
     "pospopcnt_u8_avx2_blend_popcnt_unroll8",
     "pospopcnt_u8_avx2_adder_forest",
     "pospopcnt_u8_avx2_harley_seal",
+    "pospopcnt_u8_avx2_popcnt4bit",
     "pospopcnt_u8_avx512",
     "pospopcnt_u8_avx512bw_popcnt32_mask",
     "pospopcnt_u8_avx512bw_popcnt64_mask",
@@ -544,6 +546,7 @@ void pospopcnt_u8_avx2_blend_popcnt_unroll4(const uint8_t* data, size_t len, uin
 void pospopcnt_u8_avx2_blend_popcnt_unroll8(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_blend_popcnt_unroll16(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
+void pospopcnt_u8_avx2_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_popcnt32_mask(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_popcnt64_mask(const uint8_t* data, size_t len, uint32_t* flags);

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -289,8 +289,8 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_sse_blend_popcnt_unroll4",
     "pospopcnt_u16_sse_blend_popcnt_unroll8",
     "pospopcnt_u16_sse_blend_popcnt_unroll16",
-    "pospopcnt_u16_sse2_sad",
-    "pospopcnt_u16_sse2_harley_seal",
+    "pospopcnt_u16_sse_sad",
+    "pospopcnt_u16_sse_harley_seal",
     "pospopcnt_u16_avx2_popcnt",
     "pospopcnt_u16_avx2",
     "pospopcnt_u16_avx2_naive_counter",
@@ -331,6 +331,7 @@ typedef enum {
     PPOPCNT_U8_SSE_BLEND_POPCNT_UR16,
     PPOPCNT_U8_SSE_SAD,
     PPOPCNT_U8_SSE_HARLEY_SEAL,
+    PPOPCNT_U8_SSE_POPCNT4BIT,
     PPOPCNT_U8_AVX2_POPCNT,
     PPOPCNT_U8_AVX2,
     PPOPCNT_U8_AVX2_POPCNT_NAIVE,
@@ -374,6 +375,7 @@ static const char * const pospopcnt_u8_method_names[] = {
     "pospopcnt_u8_sse_blend_popcnt_unroll8",
     "pospopcnt_u8_sse2_sad",
     "pospopcnt_u8_sse2_harley_seal",
+    "pospopcnt_u8_sse_popcnt4bit",
     "pospopcnt_u8_avx2_popcnt",
     "pospopcnt_u8_avx2",
     "pospopcnt_u8_avx2_naive_counter",
@@ -528,6 +530,7 @@ void pospopcnt_u8_sse_blend_popcnt_unroll8(const uint8_t* data, size_t len, uint
 void pospopcnt_u8_sse_blend_popcnt_unroll16(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_sse_sad(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
+void pospopcnt_u8_sse_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_popcnt(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_naive_counter(const uint8_t* data, size_t len, uint32_t* flags);


### PR DESCRIPTION
This PR provides SSE/AVX2/AVX512 implementations of a tailored 8-bit pospopcnt (`pospopcnt_u8_XXX_popcnt4bit`). This is how it looks on Skylake-X (for <= 8kB inputs it's the fastest):

```
$ ./bench 1024 100 u8_avx512bw
Will test 1024 flags. (2kB) repeated 100 times.
pospopcnt_u8_avx512bw_popcnt32_mask                    938.99
pospopcnt_u8_avx512bw_popcnt64_mask                    977.60
pospopcnt_u8_avx512bw_blend_popcnt                     611.03
pospopcnt_u8_avx512bw_blend_popcnt_unroll4             590.38
pospopcnt_u8_avx512bw_blend_popcnt_unroll8             536.10
pospopcnt_u8_avx512bw_adder_forest                     731.06
pospopcnt_u8_avx512bw_harley_seal                     1502.28
pospopcnt_u8_avx512bw_popcnt4bit                       390.27   ***
$ ./bench 2048 100 u8_avx512bw

Will test 2048 flags. (4kB) repeated 100 times.
pospopcnt_u8_avx512bw_popcnt32_mask                   1509.90
pospopcnt_u8_avx512bw_popcnt64_mask                   1591.56
pospopcnt_u8_avx512bw_blend_popcnt                     945.78
pospopcnt_u8_avx512bw_blend_popcnt_unroll4             907.06
pospopcnt_u8_avx512bw_blend_popcnt_unroll8             876.25
pospopcnt_u8_avx512bw_adder_forest                     926.67
pospopcnt_u8_avx512bw_harley_seal                     1522.95
pospopcnt_u8_avx512bw_popcnt4bit                       544.75   ***

$ ./bench 4096 100 u8_avx512bw
Will test 4096 flags. (8kB) repeated 100 times.
pospopcnt_u8_avx512bw_popcnt32_mask                   2593.32
pospopcnt_u8_avx512bw_popcnt64_mask                   2646.74
pospopcnt_u8_avx512bw_blend_popcnt                    1678.48
pospopcnt_u8_avx512bw_blend_popcnt_unroll4            1595.55
pospopcnt_u8_avx512bw_blend_popcnt_unroll8            1527.14
pospopcnt_u8_avx512bw_adder_forest                    1248.02
pospopcnt_u8_avx512bw_harley_seal                     1689.58
pospopcnt_u8_avx512bw_popcnt4bit                       840.27   ***

$ ./bench 8192 100 u8_avx512bw
Will test 8192 flags. (16kB) repeated 100 times.
pospopcnt_u8_avx512bw_popcnt32_mask                   4776.52
pospopcnt_u8_avx512bw_popcnt64_mask                   4808.20
pospopcnt_u8_avx512bw_blend_popcnt                    3116.20
pospopcnt_u8_avx512bw_blend_popcnt_unroll4            2899.04
pospopcnt_u8_avx512bw_blend_popcnt_unroll8            2836.16
pospopcnt_u8_avx512bw_adder_forest                    1871.56
pospopcnt_u8_avx512bw_harley_seal                     1876.53
pospopcnt_u8_avx512bw_popcnt4bit                      1435.73   ***
$ ./bench 16384 100 u8_avx512bw
Will test 16384 flags. (32kB) repeated 100 times.
pospopcnt_u8_avx512bw_popcnt32_mask                   9067.55
pospopcnt_u8_avx512bw_popcnt64_mask                   8968.94
pospopcnt_u8_avx512bw_blend_popcnt                    5964.30
pospopcnt_u8_avx512bw_blend_popcnt_unroll4            5514.96
pospopcnt_u8_avx512bw_blend_popcnt_unroll8            5499.79
pospopcnt_u8_avx512bw_adder_forest                    3185.22
pospopcnt_u8_avx512bw_harley_seal                     2318.70   ***
pospopcnt_u8_avx512bw_popcnt4bit                      2666.03
```