### PR TITLE
Proper incrementation order in scalar hist1x4

### DIFF
--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -807,7 +807,7 @@ int pospopcnt_u16_scalar_hist1x4(const uint16_t* data, uint32_t len, uint32_t* f
      }
      while (i < len) {
           ++low[data[i] & 255];
-          ++high[(data[++i] >> 8) & 255];
+          ++high[(data[i++] >> 8) & 255];
      }
 
      for (int i = 0; i < 256; ++i) {


### PR DESCRIPTION
Problems were visible when the length of input stream wasn't divisible by 4.