### PR TITLE
Another variant of 8-bit pospopcnt (SSE4 and AVX2 implementations)

### DIFF
--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -346,6 +346,7 @@ typedef enum {
     PPOPCNT_U8_AVX2_ADDER_FOREST,
     PPOPCNT_U8_AVX2_HARLEY_SEAL,
     PPOPCNT_U8_AVX2_POPCNT4BIT,
+    PPOPCNT_U8_AVX2_HORIZREDUCE,
     PPOPCNT_U8_AVX512,
     PPOPCNT_U8_AVX512BW_MASK32,
     PPOPCNT_U8_AVX512BW_MASK64,
@@ -393,6 +394,7 @@ static const char * const pospopcnt_u8_method_names[] = {
     "pospopcnt_u8_avx2_adder_forest",
     "pospopcnt_u8_avx2_harley_seal",
     "pospopcnt_u8_avx2_popcnt4bit",
+    "pospopcnt_u8_avx2_horizreduce",
     "pospopcnt_u8_avx512",
     "pospopcnt_u8_avx512bw_popcnt32_mask",
     "pospopcnt_u8_avx512bw_popcnt64_mask",
@@ -573,6 +575,7 @@ void pospopcnt_u8_avx2_blend_popcnt_unroll8(const uint8_t* data, size_t len, uin
 void pospopcnt_u8_avx2_blend_popcnt_unroll16(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flags);
+void pospopcnt_u8_avx2_horizreduce(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_popcnt32_mask(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx512bw_popcnt64_mask(const uint8_t* data, size_t len, uint32_t* flags);

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -332,6 +332,7 @@ typedef enum {
     PPOPCNT_U8_SSE_SAD,
     PPOPCNT_U8_SSE_HARLEY_SEAL,
     PPOPCNT_U8_SSE_POPCNT4BIT,
+    PPOPCNT_U8_SSE_HORIZREDUCE,
     PPOPCNT_U8_AVX2_POPCNT,
     PPOPCNT_U8_AVX2,
     PPOPCNT_U8_AVX2_POPCNT_NAIVE,
@@ -378,6 +379,7 @@ static const char * const pospopcnt_u8_method_names[] = {
     "pospopcnt_u8_sse2_sad",
     "pospopcnt_u8_sse2_harley_seal",
     "pospopcnt_u8_sse_popcnt4bit",
+    "pospopcnt_u8_sse_horizreduce",
     "pospopcnt_u8_avx2_popcnt",
     "pospopcnt_u8_avx2",
     "pospopcnt_u8_avx2_naive_counter",
@@ -556,6 +558,7 @@ void pospopcnt_u8_sse_blend_popcnt_unroll16(const uint8_t* data, size_t len, uin
 void pospopcnt_u8_sse_sad(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_sse_harley_seal(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_sse_popcnt4bit(const uint8_t* data, size_t len, uint32_t* flags);
+void pospopcnt_u8_sse_horizreduce(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_popcnt(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2(const uint8_t* data, size_t len, uint32_t* flags);
 void pospopcnt_u8_avx2_naive_counter(const uint8_t* data, size_t len, uint32_t* flags);


### PR DESCRIPTION
A slightly better than the recently added implementation based on 4-bit popcount. Still the fastest for rather short data. Below are results for AVX2 from Skylake-X:

```
Will test 1024 flags (8 bit proc: 1kB, 16 bit proc: 2kB, 32-bit proc: 4kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        2008.60
pospopcnt_u8_avx2_harley_seal                         2814.10
pospopcnt_u8_avx2_popcnt4bit                           780.10
pospopcnt_u8_avx2_horizreduce                          619.00 **
Will test 2048 flags (8 bit proc: 2kB, 16 bit proc: 4kB, 32-bit proc: 8kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        1618.30
pospopcnt_u8_avx2_harley_seal                         2233.60
pospopcnt_u8_avx2_popcnt4bit                           817.50
pospopcnt_u8_avx2_horizreduce                          718.50 **
Will test 4096 flags (8 bit proc: 4kB, 16 bit proc: 8kB, 32-bit proc: 16kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        2045.50
pospopcnt_u8_avx2_harley_seal                         2232.10
pospopcnt_u8_avx2_popcnt4bit                          1244.20
pospopcnt_u8_avx2_horizreduce                          832.90 **
Will test 8192 flags (8 bit proc: 8kB, 16 bit proc: 16kB, 32-bit proc: 32kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        2313.50
pospopcnt_u8_avx2_harley_seal                         2426.90
pospopcnt_u8_avx2_popcnt4bit                          1754.30
pospopcnt_u8_avx2_horizreduce                         1501.30 **
Will test 16384 flags (8 bit proc: 16kB, 16 bit proc: 32kB, 32-bit proc: 64kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        4413.30
pospopcnt_u8_avx2_harley_seal                         3305.80
pospopcnt_u8_avx2_popcnt4bit                          3264.50
pospopcnt_u8_avx2_horizreduce                         2831.50 **
Will test 32768 flags (8 bit proc: 32kB, 16 bit proc: 64kB, 32-bit proc: 128kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                        7025.40
pospopcnt_u8_avx2_harley_seal                         5267.80 
pospopcnt_u8_avx2_popcnt4bit                          6512.80
pospopcnt_u8_avx2_horizreduce                         5629.90 **
Will test 65536 flags (8 bit proc: 64kB, 16 bit proc: 128kB, 32-bit proc: 256kB) repeated 10 times.
pospopcnt_u8_avx2_adder_forest                       13724.10
pospopcnt_u8_avx2_harley_seal                         8690.20 **
pospopcnt_u8_avx2_popcnt4bit                         14443.50
pospopcnt_u8_avx2_horizreduce                        11903.40
```