### PR TITLE
A bit faster Harley-Seal-based implementations

### DIFF
--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -48,49 +48,8 @@ int pospopcnt_u16(const uint16_t* data, uint32_t len, uint32_t* flags) {
 }
 
 int pospopcnt_u16_method(PPOPCNT_U16_METHODS method, const uint16_t* data, uint32_t len, uint32_t* flags) {
-    switch(method) {
-    case(PPOPCNT_AUTO): return pospopcnt_u16(data, len, flags);
-    case(PPOPCNT_SCALAR): return pospopcnt_u16_scalar_naive(data, len, flags);
-    case(PPOPCNT_SCALAR_NOSIMD): return pospopcnt_u16_scalar_naive_nosimd(data, len, flags);
-    case(PPOPCNT_SCALAR_PARTITION): return pospopcnt_u16_scalar_partition(data, len, flags);
-    case(PPOPCNT_SCALAR_HIST1X4): return pospopcnt_u16_scalar_hist1x4(data, len, flags);
-    case(PPOPCNT_SCALAR_UMUL128): return pospopcnt_u16_scalar_umul128(data, len, flags);
-    case(PPOPCNT_SCALAR_UMUL128_UR2): return pospopcnt_u16_scalar_umul128_unroll2(data, len, flags);
-    case(PPOPCNT_SSE_SINGLE): return pospopcnt_u16_sse_single(data, len, flags);
-    case(PPOPCNT_SSE_BLEND_POPCNT): return pospopcnt_u16_sse_blend_popcnt(data, len, flags);
-    case(PPOPCNT_SSE_BLEND_POPCNT_UR4): return pospopcnt_u16_sse_blend_popcnt_unroll4(data, len, flags);
-    case(PPOPCNT_SSE_BLEND_POPCNT_UR8): return pospopcnt_u16_sse_blend_popcnt_unroll8(data, len, flags);
-    case(PPOPCNT_SSE_BLEND_POPCNT_UR16): return pospopcnt_u16_sse_blend_popcnt_unroll16(data, len, flags);
-    case(PPOPCNT_SSE_SAD): return pospopcnt_u16_sse_sad(data, len, flags);
-    case(PPOPCNT_SSE_HARLEY_SEAL): return pospopcnt_u16_sse_harley_seal(data, len, flags);
-    case(PPOPCNT_AVX2_POPCNT): return pospopcnt_u16_avx2_popcnt(data, len, flags);
-    case(PPOPCNT_AVX2): return pospopcnt_u16_avx2(data, len, flags);
-    case(PPOPCNT_AVX2_POPCNT_NAIVE): return pospopcnt_u16_avx2_naive_counter(data, len, flags);
-    case(PPOPCNT_AVX2_SINGLE): return pospopcnt_u16_avx2_single(data, len, flags);
-    case(PPOPCNT_AVX2_LEMIRE1): return pospopcnt_u16_avx2_lemire(data, len, flags);
-    case(PPOPCNT_AVX2_LEMIRE2): return pospopcnt_u16_avx2_lemire2(data, len, flags);
-    case(PPOPCNT_AVX2_BLEND_POPCNT): return pospopcnt_u16_avx2_blend_popcnt(data, len, flags);
-    case(PPOPCNT_AVX2_BLEND_POPCNT_UR4): return pospopcnt_u16_avx2_blend_popcnt_unroll4(data, len, flags);
-    case(PPOPCNT_AVX2_BLEND_POPCNT_UR8): return pospopcnt_u16_avx2_blend_popcnt_unroll8(data, len, flags);
-    case(PPOPCNT_AVX2_BLEND_POPCNT_UR16): return pospopcnt_u16_avx2_blend_popcnt_unroll16(data, len, flags);
-    case(PPOPCNT_AVX2_ADDER_FOREST): return pospopcnt_u16_avx2_adder_forest(data, len, flags);
-    case(PPOPCNT_AVX2_HARLEY_SEAL): return pospopcnt_u16_avx2_harley_seal(data, len, flags);
-    case(PPOPCNT_AVX512): return pospopcnt_u16_avx512(data, len, flags);
-    case(PPOPCNT_AVX512BW_MASK32): return pospopcnt_u16_avx512bw_popcnt32_mask(data, len, flags);
-    case(PPOPCNT_AVX512BW_MASK64): return pospopcnt_u16_avx512bw_popcnt64_mask(data, len, flags);
-    case(PPOPCNT_AVX512_MASKED_OPS): return pospopcnt_u16_avx512_masked_ops(data, len, flags);
-    case(PPOPCNT_AVX512_POPCNT): return pospopcnt_u16_avx512_popcnt(data, len, flags);
-    case(PPOPCNT_AVX512BW_BLEND_POPCNT): return pospopcnt_u16_avx512bw_blend_popcnt(data, len, flags);
-    case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR4): return pospopcnt_u16_avx512bw_blend_popcnt_unroll4(data, len, flags);
-    case(PPOPCNT_AVX512BW_BLEND_POPCNT_UR8): return pospopcnt_u16_avx512bw_blend_popcnt_unroll8(data, len, flags);
-    case(PPOPCNT_AVX512BW_ADDER_FOREST): return pospopcnt_u16_avx512bw_adder_forest(data, len, flags);
-    case(PPOPCNT_AVX512_MULA2): return pospopcnt_u16_avx512_mula2(data, len, flags);
-    case(PPOPCNT_AVX512BW_HARLEY_SEAL): return pospopcnt_u16_avx512bw_harley_seal(data, len, flags);
-    case(PPOPCNT_AVX512VBMI_HARLEY_SEAL): return pospopcnt_u16_avx512vbmi_harley_seal(data, len, flags);
-    case PPOPCNT_NUMBER_METHODS: break; /* -Wswitch */
-    }
-    assert(0);
-    return 0; /* unreachable, but some compilers complain without it */
+    pospopcnt_u16_method_type pospopcnt_u16 = get_pospopcnt_u16_method(method);
+    return pospopcnt_u16(data, len, flags);
 }
 
 pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method) {
@@ -122,6 +81,7 @@ pospopcnt_u16_method_type get_pospopcnt_u16_method(PPOPCNT_U16_METHODS method) {
     case(PPOPCNT_AVX2_BLEND_POPCNT_UR16): return pospopcnt_u16_avx2_blend_popcnt_unroll16;
     case(PPOPCNT_AVX2_ADDER_FOREST): return pospopcnt_u16_avx2_adder_forest;
     case(PPOPCNT_AVX2_HARLEY_SEAL): return pospopcnt_u16_avx2_harley_seal;
+    case(PPOPCNT_AVX2_HARLEY_SEAL_IMPROVED): return pospopcnt_u16_avx2_harley_seal_improved;
     case(PPOPCNT_AVX512): return pospopcnt_u16_avx512;
     case(PPOPCNT_AVX512BW_MASK32): return pospopcnt_u16_avx512bw_popcnt32_mask;
     case(PPOPCNT_AVX512BW_MASK64): return pospopcnt_u16_avx512bw_popcnt64_mask;
@@ -1714,6 +1674,140 @@ int pospopcnt_u16_avx2_harley_seal(const uint16_t* array, uint32_t len, uint32_t
     return 0;
 }
 
+int pospopcnt_u16_avx2_harley_seal_improved(const uint16_t* array, uint32_t len, uint32_t* flags) {
+    for (uint32_t i = len - (len % (16 * 16)); i < len; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            flags[j] += ((array[i] & (1 << j)) >> j);
+        }
+    }
+
+    const __m256i* data = (const __m256i*)array;
+    size_t size = len / 16;
+    __m256i v1  = _mm256_setzero_si256();
+    __m256i v2  = _mm256_setzero_si256();
+    __m256i v4  = _mm256_setzero_si256();
+    __m256i v8  = _mm256_setzero_si256();
+    __m256i v16 = _mm256_setzero_si256();
+    __m256i twosA, twosB, foursA, foursB, eightsA, eightsB;
+
+    const uint64_t limit = size - size % 16;
+    uint64_t i = 0;
+    uint16_t buffer[16];
+    __m256i counter[4];
+    for (size_t i = 0; i < 4; ++i) {
+        counter[i] = _mm256_setzero_si256();
+    }
+
+    while (i < limit) {
+
+        size_t thislimit = limit;
+        if (thislimit - i >= (1 << 16))
+            thislimit = i + (1 << 16) - 1;
+
+        for (/**/; i < thislimit; i += 16) {
+#define horizreduce(input, mask, shift, output) \
+        __m256i output; \
+        { \
+            const __m256i tmp0 = _mm256_and_si256(input, mask); \
+            const __m256i tmp1 = _mm256_and_si256(_mm256_srli_epi32(input, shift), mask); \
+            output = _mm256_hadd_epi16(tmp0, tmp1); \
+        }
+
+            pospopcnt_csa_avx2(&twosA,  &v1, _mm256_loadu_si256(data + i +  0), _mm256_loadu_si256(data + i +  1));
+            pospopcnt_csa_avx2(&twosB,  &v1, _mm256_loadu_si256(data + i +  2), _mm256_loadu_si256(data + i +  3));
+            pospopcnt_csa_avx2(&foursA, &v2, twosA, twosB);
+            pospopcnt_csa_avx2(&twosA,  &v1, _mm256_loadu_si256(data + i +  4), _mm256_loadu_si256(data + i +  5));
+            pospopcnt_csa_avx2(&twosB,  &v1, _mm256_loadu_si256(data + i +  6), _mm256_loadu_si256(data + i +  7));
+            pospopcnt_csa_avx2(&foursB, &v2, twosA, twosB);
+            pospopcnt_csa_avx2(&eightsA,&v4, foursA, foursB);
+            pospopcnt_csa_avx2(&twosA,  &v1, _mm256_loadu_si256(data + i +  8),  _mm256_loadu_si256(data + i +  9));
+            pospopcnt_csa_avx2(&twosB,  &v1, _mm256_loadu_si256(data + i + 10),  _mm256_loadu_si256(data + i + 11));
+            pospopcnt_csa_avx2(&foursA, &v2, twosA, twosB);
+            pospopcnt_csa_avx2(&twosA,  &v1, _mm256_loadu_si256(data + i + 12),  _mm256_loadu_si256(data + i + 13));
+            pospopcnt_csa_avx2(&twosB,  &v1, _mm256_loadu_si256(data + i + 14),  _mm256_loadu_si256(data + i + 15));
+            pospopcnt_csa_avx2(&foursB, &v2, twosA, twosB);
+            pospopcnt_csa_avx2(&eightsB,&v4, foursA, foursB);
+            {
+                horizreduce(v16, _mm256_set1_epi8(0x55), 1, t0); // t0 = 2-bit counters
+                horizreduce(t0,  _mm256_set1_epi8(0x33), 2, t1); // t1 = 4-bit counters
+                horizreduce(t1,  _mm256_set1_epi8(0x0f), 4, t2); // t2 = 8-bit counters
+
+                const __m256i mask_byte0 = _mm256_set1_epi32(0x000000ff);
+                counter[0] = _mm256_add_epi32(counter[0], t2 & mask_byte0);
+                counter[1] = _mm256_add_epi32(counter[1], _mm256_srli_epi32(t2, 1*8) & mask_byte0);
+                counter[2] = _mm256_add_epi32(counter[2], _mm256_srli_epi32(t2, 2*8) & mask_byte0);
+                counter[3] = _mm256_add_epi32(counter[3], _mm256_srli_epi32(t2, 3*8) & mask_byte0);
+            }
+            pospopcnt_csa_avx2(&v16, &v8, eightsA, eightsB);
+        } // for
+
+        // update the counters after the last iteration
+        {
+            horizreduce(v16, _mm256_set1_epi8(0x55), 1, t0);
+            horizreduce(t0,  _mm256_set1_epi8(0x33), 2, t1);
+            horizreduce(t1,  _mm256_set1_epi8(0x0f), 4, t2);
+
+            const __m256i mask_byte0 = _mm256_set1_epi32(0x000000ff);
+            counter[0] = _mm256_add_epi32(counter[0], t2 & mask_byte0);
+            counter[1] = _mm256_add_epi32(counter[1], _mm256_srli_epi32(t2, 1*8) & mask_byte0);
+            counter[2] = _mm256_add_epi32(counter[2], _mm256_srli_epi32(t2, 2*8) & mask_byte0);
+            counter[3] = _mm256_add_epi32(counter[3], _mm256_srli_epi32(t2, 3*8) & mask_byte0);
+        }
+#undef horizreduce
+    }
+
+    counter[0] = _mm256_slli_epi32(counter[0], 4); // * 16
+    counter[1] = _mm256_slli_epi32(counter[1], 4); // * 16
+    counter[2] = _mm256_slli_epi32(counter[2], 4); // * 16
+    counter[3] = _mm256_slli_epi32(counter[3], 4); // * 16
+
+    flags[0] += _mm256_extract_epi32(counter[0], 0) + _mm256_extract_epi32(counter[0], 4);
+    flags[1] += _mm256_extract_epi32(counter[2], 0) + _mm256_extract_epi32(counter[2], 4);
+    flags[2] += _mm256_extract_epi32(counter[0], 1) + _mm256_extract_epi32(counter[0], 5);
+    flags[3] += _mm256_extract_epi32(counter[2], 1) + _mm256_extract_epi32(counter[2], 5);
+    flags[4] += _mm256_extract_epi32(counter[0], 2) + _mm256_extract_epi32(counter[0], 6);
+    flags[5] += _mm256_extract_epi32(counter[2], 2) + _mm256_extract_epi32(counter[2], 6);
+    flags[6] += _mm256_extract_epi32(counter[0], 3) + _mm256_extract_epi32(counter[0], 7);
+    flags[7] += _mm256_extract_epi32(counter[2], 3) + _mm256_extract_epi32(counter[2], 7);
+
+    flags[8]  += _mm256_extract_epi32(counter[1], 0) + _mm256_extract_epi32(counter[1], 4);
+    flags[9]  += _mm256_extract_epi32(counter[3], 0) + _mm256_extract_epi32(counter[3], 4);
+    flags[10] += _mm256_extract_epi32(counter[1], 1) + _mm256_extract_epi32(counter[1], 5);
+    flags[11] += _mm256_extract_epi32(counter[3], 1) + _mm256_extract_epi32(counter[3], 5);
+    flags[12] += _mm256_extract_epi32(counter[1], 2) + _mm256_extract_epi32(counter[1], 6);
+    flags[13] += _mm256_extract_epi32(counter[3], 2) + _mm256_extract_epi32(counter[3], 6);
+    flags[14] += _mm256_extract_epi32(counter[1], 3) + _mm256_extract_epi32(counter[1], 7);
+    flags[15] += _mm256_extract_epi32(counter[3], 3) + _mm256_extract_epi32(counter[3], 7);
+
+    _mm256_storeu_si256((__m256i*)buffer, v1);
+    for (size_t i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            flags[j] += ((buffer[i] & (1 << j)) >> j);
+        }
+    }
+
+    _mm256_storeu_si256((__m256i*)buffer, v2);
+    for (size_t i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            flags[j] += 2 * ((buffer[i] & (1 << j)) >> j);
+        }
+    }
+    _mm256_storeu_si256((__m256i*)buffer, v4);
+    for (size_t i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            flags[j] += 4 * ((buffer[i] & (1 << j)) >> j);
+        }
+    }
+    _mm256_storeu_si256((__m256i*)buffer, v8);
+    for (size_t i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            flags[j] += 8 * ((buffer[i] & (1 << j)) >> j);
+        }
+    }
+    return 0;
+}
+
+
 int pospopcnt_u16_avx2_blend_popcnt_unroll4(const uint16_t* array, uint32_t len, uint32_t* flags) {
     const __m256i* data_vectors = (const __m256i*)(array);
     const uint32_t n_cycles = len / 16;
@@ -2461,6 +2555,7 @@ pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll8)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_blend_popcnt_unroll16)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_adder_forest)
 pospopcnt_u16_stub(pospopcnt_u16_avx2_harley_seal)
+pospopcnt_u16_stub(pospopcnt_u16_avx2_harley_seal_improved)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_lemire)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_lemire2)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_blend_popcnt)
@@ -2902,6 +2997,7 @@ int pospopcnt_u16_sse_harley_seal_improved(const uint16_t* array, uint32_t len, 
             counter[2] = _mm_add_epi32(counter[2], _mm_srli_epi32(t2, 2*8) & mask_byte0);
             counter[3] = _mm_add_epi32(counter[3], _mm_srli_epi32(t2, 3*8) & mask_byte0);
         }
+#undef horizreduce
     }
 
     counter[0] = _mm_slli_epi32(counter[0], 4); // * 16
@@ -3593,6 +3689,7 @@ pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll4)
 pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll8)
 pospopcnt_u16_stub(pospopcnt_u16_sse_blend_popcnt_unroll16)
 pospopcnt_u16_stub(pospopcnt_u16_sse_harley_seal)
+pospopcnt_u16_stub(pospopcnt_u16_sse_harley_seal_improved)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll4)
 pospopcnt_u8_stub(pospopcnt_u8_sse_blend_popcnt_unroll8)

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -3699,6 +3699,7 @@ pospopcnt_u8_stub(pospopcnt_u8_sse_harley_seal)
 pospopcnt_u8_stub(pospopcnt_u8_sse_popcnt4bit)
 pospopcnt_u8_stub(pospopcnt_u8_sse_horizreduce)
 pospopcnt_u32_stub(pospopcnt_u32_sse_harley_seal)
+pospopcnt_u32_stub(pospopcnt_u32_sse_harley_seal_improved)
 #endif
 
 #if POSPOPCNT_SIMD_VERSION >= 6

--- a/pospopcnt.c
+++ b/pospopcnt.c
@@ -2565,6 +2565,7 @@ pospopcnt_u8_stub(pospopcnt_u8_avx2_blend_popcnt_unroll16)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_adder_forest)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_harley_seal)
 pospopcnt_u8_stub(pospopcnt_u8_avx2_popcnt4bit)
+pospopcnt_u8_stub(pospopcnt_u8_avx2_horizreduce)
 pospopcnt_u32_stub(pospopcnt_u32_avx2_harley_seal)
 pospopcnt_u32_stub(pospopcnt_u32_avx2_harley_seal_improved)
 #endif

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -261,6 +261,7 @@ typedef enum {
     PPOPCNT_AVX2_BLEND_POPCNT_UR16,
     PPOPCNT_AVX2_ADDER_FOREST,
     PPOPCNT_AVX2_HARLEY_SEAL,
+    PPOPCNT_AVX2_HARLEY_SEAL_IMPROVED,
     PPOPCNT_AVX512,
     PPOPCNT_AVX512BW_MASK32,
     PPOPCNT_AVX512BW_MASK64,
@@ -305,6 +306,7 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_avx2_blend_popcnt_unroll16",
     "pospopcnt_u16_avx2_adder_forest",
     "pospopcnt_u16_avx2_harley_seal",
+    "pospopcnt_u16_avx2_harley_seal_improved",
     "pospopcnt_u16_avx512",
     "pospopcnt_u16_avx512bw_popcnt32_mask",
     "pospopcnt_u16_avx512bw_popcnt64_mask",
@@ -523,6 +525,7 @@ int pospopcnt_u16_avx2_blend_popcnt_unroll4(const uint16_t* data, uint32_t len, 
 int pospopcnt_u16_avx2_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_avx2_harley_seal_improved(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512bw_popcnt32_mask(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx512bw_popcnt64_mask(const uint16_t* data, uint32_t len, uint32_t* flags);

--- a/pospopcnt.h
+++ b/pospopcnt.h
@@ -248,6 +248,7 @@ typedef enum {
     PPOPCNT_SSE_BLEND_POPCNT_UR16,
     PPOPCNT_SSE_SAD,
     PPOPCNT_SSE_HARLEY_SEAL,
+    PPOPCNT_SSE_HARLEY_SEAL_IMPROVED,
     PPOPCNT_AVX2_POPCNT,
     PPOPCNT_AVX2,
     PPOPCNT_AVX2_POPCNT_NAIVE,
@@ -291,6 +292,7 @@ static const char * const pospopcnt_u16_method_names[] = {
     "pospopcnt_u16_sse_blend_popcnt_unroll16",
     "pospopcnt_u16_sse_sad",
     "pospopcnt_u16_sse_harley_seal",
+    "pospopcnt_u16_sse_harley_seal_improved",
     "pospopcnt_u16_avx2_popcnt",
     "pospopcnt_u16_avx2",
     "pospopcnt_u16_avx2_naive_counter",
@@ -507,6 +509,7 @@ int pospopcnt_u16_sse_blend_popcnt_unroll8(const uint16_t* data, uint32_t len, u
 int pospopcnt_u16_sse_blend_popcnt_unroll16(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_sse_sad(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_sse_harley_seal(const uint16_t* data, uint32_t len, uint32_t* flags);
+int pospopcnt_u16_sse_harley_seal_improved(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_popcnt(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2(const uint16_t* data, uint32_t len, uint32_t* flags);
 int pospopcnt_u16_avx2_naive_counter(const uint16_t* data, uint32_t len, uint32_t* flags);


### PR DESCRIPTION
The new approach is a bit faster for bigger tables. Below are results from Skylake-X

```
Will test 1024 flags (8 bit proc: 1kB, 16 bit proc: 2kB, 32-bit proc: 4kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                       2220.10
pospopcnt_u16_avx2_blend_popcnt_unroll4               1952.90
pospopcnt_u16_avx2_blend_popcnt_unroll8               1796.70 **
pospopcnt_u16_avx2_blend_popcnt_unroll16              1964.00 
pospopcnt_u16_avx2_adder_forest                       2181.20
pospopcnt_u16_avx2_harley_seal                        3043.50
pospopcnt_u16_avx2_harley_seal_improved               4311.20
Will test 2048 flags (8 bit proc: 2kB, 16 bit proc: 4kB, 32-bit proc: 8kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                       2951.90
pospopcnt_u16_avx2_blend_popcnt_unroll4               2575.20
pospopcnt_u16_avx2_blend_popcnt_unroll8               2362.80 
pospopcnt_u16_avx2_blend_popcnt_unroll16              2617.30
pospopcnt_u16_avx2_adder_forest                       2198.80
pospopcnt_u16_avx2_harley_seal                        2352.00 **
pospopcnt_u16_avx2_harley_seal_improved               3048.50
Will test 4096 flags (8 bit proc: 4kB, 16 bit proc: 8kB, 32-bit proc: 16kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                       4184.10
pospopcnt_u16_avx2_blend_popcnt_unroll4               3606.70
pospopcnt_u16_avx2_blend_popcnt_unroll8               3367.80
pospopcnt_u16_avx2_blend_popcnt_unroll16              3627.20
pospopcnt_u16_avx2_adder_forest                       2511.70
pospopcnt_u16_avx2_harley_seal                        2212.00 **
pospopcnt_u16_avx2_harley_seal_improved               2676.00
Will test 8192 flags (8 bit proc: 8kB, 16 bit proc: 16kB, 32-bit proc: 32kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                      10809.80
pospopcnt_u16_avx2_blend_popcnt_unroll4               7405.70
pospopcnt_u16_avx2_blend_popcnt_unroll8               6791.20
pospopcnt_u16_avx2_blend_popcnt_unroll16              7121.70
pospopcnt_u16_avx2_adder_forest                       4310.70
pospopcnt_u16_avx2_harley_seal                        3285.40 **
pospopcnt_u16_avx2_harley_seal_improved               3450.10
Will test 16384 flags (8 bit proc: 16kB, 16 bit proc: 32kB, 32-bit proc: 64kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                      20484.70
pospopcnt_u16_avx2_blend_popcnt_unroll4              14950.10
pospopcnt_u16_avx2_blend_popcnt_unroll8              13575.50
pospopcnt_u16_avx2_blend_popcnt_unroll16             14041.70
pospopcnt_u16_avx2_adder_forest                       7984.10
pospopcnt_u16_avx2_harley_seal                        5166.40
pospopcnt_u16_avx2_harley_seal_improved               5090.30 **
Will test 32768 flags (8 bit proc: 32kB, 16 bit proc: 64kB, 32-bit proc: 128kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                      53496.40
pospopcnt_u16_avx2_blend_popcnt_unroll4              32143.30
pospopcnt_u16_avx2_blend_popcnt_unroll8              27192.30
pospopcnt_u16_avx2_blend_popcnt_unroll16             28141.30
pospopcnt_u16_avx2_adder_forest                      15671.30
pospopcnt_u16_avx2_harley_seal                        9270.00
pospopcnt_u16_avx2_harley_seal_improved               8360.70 **
Will test 65536 flags (8 bit proc: 64kB, 16 bit proc: 128kB, 32-bit proc: 256kB) repeated 10 times.
pospopcnt_u16_avx2_blend_popcnt                     106907.90
pospopcnt_u16_avx2_blend_popcnt_unroll4              63850.00
pospopcnt_u16_avx2_blend_popcnt_unroll8              54070.50
pospopcnt_u16_avx2_blend_popcnt_unroll16             55831.70
pospopcnt_u16_avx2_adder_forest                      30480.40
pospopcnt_u16_avx2_harley_seal                       16852.60
pospopcnt_u16_avx2_harley_seal_improved              14529.40 **
```